### PR TITLE
Update .spi.yml

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -5,3 +5,4 @@ builder:
     - SwiftNavigation
     - SwiftUINavigation
     - UIKitNavigation
+    swift_version: 6.0


### PR DESCRIPTION
It currently [errors out](https://swiftpackageindex.com/builds/462BF75D-F1E3-4836-BBF5-C1A9136359F3) with

```
error: 'docc convert' invocation failed with a nonzero exit code: '5'
```

which looks like a docc error. I can reproduce the same error simply by running

```
env DEVELOPER_DIR=/Applications/Xcode-15.4.0.app xcrun swift package --disable-sandbox preview-documentation -p 8080 --target SwiftNavigation
```

It works with

```
env DEVELOPER_DIR=/Applications/Xcode-16.0.0-Beta.4.app xcrun swift package --disable-sandbox preview-documentation -p 8080 --target SwiftNavigation
```

so this switches to Swift 6 for doc generation.

(NB: We always build docs with the latest Swift _release_ so this change becomes superfluous once Swift 6 is released and would pin to an older Swift version once 6.1+ are released and should be removed before then.)