### PR TITLE
Dismiss presented controller when parent controller goes away

### DIFF
--- a/Examples/CaseStudiesTests/PresentationTests.swift
+++ b/Examples/CaseStudiesTests/PresentationTests.swift
@@ -405,6 +405,7 @@ final class PresentationTests: XCTestCase {
     nav.pushViewController(child!, animated: false)
     await assertEventuallyEqual(nav.viewControllers.count, 2)
 
+    try await Task.sleep(for: .seconds(0.5))
     withUITransaction(\.uiKit.disablesAnimations, true) {
       child!.model.isPresented = true
     }
@@ -415,9 +416,6 @@ final class PresentationTests: XCTestCase {
     nav.popToRootViewController(animated: false)
     try await Task.sleep(for: .seconds(0.5))
 
-    XCTExpectFailure {
-      $0.compactDescription.hasPrefix("failed - Binding failed to write")
-    }
     child = nil
     try await Task.sleep(for: .seconds(0.5))
 

--- a/Sources/UIKitNavigation/Navigation/Presentation.swift
+++ b/Sources/UIKitNavigation/Navigation/Presentation.swift
@@ -448,6 +448,9 @@
     weak var controller: UIViewController?
     let presentationID: AnyHashable?
     deinit {
+      // NB: This can only be assumed because it is held in a UIViewController and is guaranteed to
+      //     deinit alongside it on the main thread. If we use this other places we should force it
+      //     to be a UIViewController as well, to ensure this functionality.
       MainActor.assumeIsolated {
         self.controller?.dismiss(animated: false)
       }

--- a/Sources/UIKitNavigation/Navigation/Presentation.swift
+++ b/Sources/UIKitNavigation/Navigation/Presentation.swift
@@ -443,9 +443,15 @@
     }
   }
 
+  @MainActor
   private class Presented {
     weak var controller: UIViewController?
     let presentationID: AnyHashable?
+    deinit {
+      MainActor.assumeIsolated {
+        self.controller?.dismiss(animated: false)
+      }
+    }
     init(_ controller: UIViewController, id presentationID: AnyHashable? = nil) {
       self.controller = controller
       self.presentationID = presentationID


### PR DESCRIPTION
This brings parity with SwiftUI, where if a view disappears, an attached sheet disappears shortly thereafter.