### PR TITLE
Remove UIKitNavigation dependency from SwiftUINavigation

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -51,7 +51,6 @@ let package = Package(
     .target(
       name: "SwiftUINavigation",
       dependencies: [
-        "UIKitNavigation",
         .product(name: "CasePaths", package: "swift-case-paths"),
         .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
       ]

--- a/Sources/SwiftUINavigation/Internal/Exports.swift
+++ b/Sources/SwiftUINavigation/Internal/Exports.swift
@@ -1,5 +1,4 @@
 #if canImport(SwiftUI)
   @_exported import CasePaths
   @_exported import SwiftNavigation
-  @_exported import UIKitNavigation
 #endif  // canImport(SwiftUI)


### PR DESCRIPTION
`SwiftUINavigation` is currently depending on `UIKitNavigation`.

This seems strange to me so I tried to remove it. Unit test have passed so I'm proposing the change 🙂 