### PR TITLE
Restore `ActionSheet` extension

### DIFF
--- a/Sources/SwiftUINavigation/Alert.swift
+++ b/Sources/SwiftUINavigation/Alert.swift
@@ -256,5 +256,4 @@
       }
     }
   }
-
 #endif  // canImport(SwiftUI)

--- a/Sources/SwiftUINavigation/ConfirmationDialog.swift
+++ b/Sources/SwiftUINavigation/ConfirmationDialog.swift
@@ -221,4 +221,43 @@
       }
     }
   }
+
+  @available(
+    iOS,
+    introduced: 13,
+    deprecated: 100000,
+    message:
+      "use 'View.confirmationDialog(title:isPresented:titleVisibility:presenting::actions:)' instead."
+  )
+  @available(
+    macOS,
+    introduced: 12,
+    unavailable
+  )
+  @available(
+    tvOS,
+    introduced: 13,
+    deprecated: 100000,
+    message:
+      "use 'View.confirmationDialog(title:isPresented:titleVisibility:presenting::actions:)' instead."
+  )
+  @available(
+    watchOS,
+    introduced: 6,
+    deprecated: 100000,
+    message:
+      "use 'View.confirmationDialog(title:isPresented:titleVisibility:presenting::actions:)' instead."
+  )
+  extension ActionSheet {
+    public init<Action>(
+      _ state: ConfirmationDialogState<Action>,
+      action: @escaping (Action?) -> Void
+    ) {
+      self.init(
+        title: Text(state.title),
+        message: state.message.map { Text($0) },
+        buttons: state.buttons.map { .init($0, action: action) }
+      )
+    }
+  }
 #endif  // canImport(SwiftUI)


### PR DESCRIPTION
We lost this deprecation when 2.0.0 was released, but it's a SwiftUI-related interface and not a library deprecation, so I think it should still be available on iOS 13 (we use it in TCA).