### PR TITLE
Change Navigation Stack Controller's initializers to be required

### DIFF
--- a/Examples/CaseStudies/UIKit/StaticNavigationStackController.swift
+++ b/Examples/CaseStudies/UIKit/StaticNavigationStackController.swift
@@ -15,9 +15,8 @@ final class StaticNavigationStackController: NavigationStackController, UIKitCas
   let isPresentedInSheet = true
   private var model: Model!
 
-  @MainActor
-  convenience init() {
-    @UIBindable var model = Model()
+  convenience init(model: Model) {
+    @UIBindable var model = model
     self.init(path: $model.path) {
       RootViewController(model: model)
     }
@@ -170,5 +169,5 @@ private class FeatureViewController: UIViewController {
 }
 
 #Preview {
-  StaticNavigationStackController()
+  StaticNavigationStackController(model: StaticNavigationStackController.Model())
 }

--- a/Examples/CaseStudies/UIKit/UIKitCaseStudies.swift
+++ b/Examples/CaseStudies/UIKit/UIKitCaseStudies.swift
@@ -19,7 +19,7 @@ struct UIKitCaseStudiesView: View {
         ConciseEnumNavigationViewController()
       }
       CaseStudyGroupView("Stack navigation") {
-        StaticNavigationStackController()
+        StaticNavigationStackController(model: StaticNavigationStackController.Model())
         ErasedNavigationStackController(model: ErasedNavigationStackController.Model())
         // TODO: state restoration
       }

--- a/Sources/UIKitNavigation/Navigation/NavigationStackController.swift
+++ b/Sources/UIKitNavigation/Navigation/NavigationStackController.swift
@@ -27,32 +27,36 @@
       set { pathDelegate.base = newValue }
     }
 
-    public convenience init<Data: RandomAccessCollection & RangeReplaceableCollection>(
+    public required init<Data: RandomAccessCollection & RangeReplaceableCollection>(
       navigationBarClass: AnyClass? = nil,
       toolbarClass: AnyClass? = nil,
       path: UIBinding<Data>,
       root: () -> UIViewController
     ) where Data.Element: Hashable {
-      self.init(navigationBarClass: navigationBarClass, toolbarClass: toolbarClass)
+      super.init(navigationBarClass: navigationBarClass, toolbarClass: toolbarClass)
       self._path = path.path
       let root = root()
       self.root = root
       self.viewControllers = [root]
     }
 
-    public convenience init(
+    public required init(
       navigationBarClass: AnyClass? = nil,
       toolbarClass: AnyClass? = nil,
       path: UIBinding<UINavigationPath>,
       root: () -> UIViewController
     ) {
-      self.init(navigationBarClass: navigationBarClass, toolbarClass: toolbarClass)
+      super.init(navigationBarClass: navigationBarClass, toolbarClass: toolbarClass)
       self._path = path.elements
       let root = root()
       self.root = root
       self.viewControllers = [root]
     }
-
+    
+    public required init?(coder aDecoder: NSCoder) {
+      fatalError("init(coder:) has not been implemented")
+    }
+    
     open override func viewDidLoad() {
       super.viewDidLoad()
 


### PR DESCRIPTION
Initialization rules otherwise prevent Swift from seeing downstream initializers.