### PR TITLE
Delay `UIAlertController.onDismiss`

### DIFF
--- a/Sources/UIKitNavigationShim/shim.m
+++ b/Sources/UIKitNavigationShim/shim.m
@@ -51,8 +51,15 @@
       [self UIKitNavigation_viewDidDisappear:animated];
 
       if ((self.isBeingDismissed || self.isMovingFromParentViewController) && self.onDismiss != NULL) {
-        self.onDismiss();
-        self.onDismiss = nil;
+        if ([self isKindOfClass:UIAlertController.class]) {
+          dispatch_async(dispatch_get_main_queue(), ^{
+            self.onDismiss();
+            self.onDismiss = nil;
+          });
+        } else {
+          self.onDismiss();
+          self.onDismiss = nil;
+        }
       }
     }
 


### PR DESCRIPTION
Currently, `onDismiss` is called _before_ the `UIAlertAction` is processed, which generally isn't an issue, but if you care about the order of operations, this can be a bit thorny. In the case of highly generalized navigation patterns in TCA, the order is what we use to emit warnings when invalid actions are received (like a `dismiss` action is received for an already-dismissed feature), so let's address the problem with a quick tick.

We could do this thread hop unconditionally if it makes sense to, but let's localize to `UIAlertController` for now.