### PR TITLE
Bring back deprecated SwiftUINavigation alerts

### DIFF
--- a/Sources/SwiftNavigation/ConfirmationDialogState.swift
+++ b/Sources/SwiftNavigation/ConfirmationDialogState.swift
@@ -144,7 +144,6 @@ public struct ConfirmationDialogState<Action>: Identifiable {
   ///   - title: The title of the dialog.
   ///   - actions: A ``ButtonStateBuilder`` returning the dialog's actions.
   ///   - message: The message for the dialog.
-  @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
   public init(
     titleVisibility: ConfirmationDialogStateTitleVisibility,
     title: () -> TextState,

--- a/Sources/SwiftNavigation/Internal/Deprecations.swift
+++ b/Sources/SwiftNavigation/Internal/Deprecations.swift
@@ -1,0 +1,128 @@
+extension AlertState {
+  @available(*, deprecated, message: "Use 'init(title:actions:message:)' instead.")
+  public init(
+    title: TextState,
+    message: TextState? = nil,
+    buttons: [ButtonState<Action>]
+  ) {
+    self.init(
+      title: { title },
+      actions: {
+        for button in buttons {
+          button
+        }
+      },
+      message: message.map { message in { message } }
+    )
+  }
+
+  @available(*, deprecated, message: "Use 'init(title:actions:message:)' instead.")
+  public init(
+    title: TextState,
+    message: TextState? = nil,
+    dismissButton: ButtonState<Action>? = nil
+  ) {
+    self.init(
+      title: { title },
+      actions: {
+        if let dismissButton {
+          dismissButton
+        }
+      },
+      message: message.map { message in { message } }
+    )
+  }
+
+  @available(*, deprecated, message: "Use 'init(title:actions:message:)' instead.")
+  public init(
+    title: TextState,
+    message: TextState? = nil,
+    primaryButton: ButtonState<Action>,
+    secondaryButton: ButtonState<Action>
+  ) {
+    self.init(
+      title: { title },
+      actions: {
+        primaryButton
+        secondaryButton
+      },
+      message: message.map { message in { message } }
+    )
+  }
+}
+
+extension ButtonState {
+  @available(*, deprecated, message: "Use 'ButtonState(role: .cancel, action:label:)' instead.")
+  public static func cancel(
+    _ label: TextState, action: ButtonStateAction<Action> = .send(nil)
+  ) -> Self {
+    Self(role: .cancel, action: action) {
+      label
+    }
+  }
+
+  @available(*, deprecated, message: "Use 'ButtonState(action:label:)' instead.")
+  public static func `default`(
+    _ label: TextState, action: ButtonStateAction<Action> = .send(nil)
+  ) -> Self {
+    Self(action: action) {
+      label
+    }
+  }
+
+  @available(
+    *, deprecated, message: "Use 'ButtonState(role: .destructive, action:label:)' instead."
+  )
+  public static func destructive(
+    _ label: TextState, action: ButtonStateAction<Action> = .send(nil)
+  ) -> Self {
+    Self(role: .destructive, action: action) {
+      label
+    }
+  }
+}
+
+@available(iOS 13, macOS 12, tvOS 13, watchOS 6, *)
+extension ConfirmationDialogState {
+  @available(*, deprecated, message: "Use 'init(titleVisibility:title:actions:message:)' instead.")
+  public init(
+    title: TextState,
+    titleVisibility: ConfirmationDialogStateTitleVisibility,
+    message: TextState? = nil,
+    buttons: [ButtonState<Action>] = []
+  ) {
+    self.init(
+      titleVisibility: titleVisibility,
+      title: { title },
+      actions: {
+        for button in buttons {
+          button
+        }
+      },
+      message: message.map { message in { message } }
+    )
+  }
+
+  @available(*, deprecated, message: "Use 'init(title:actions:message:)' instead.")
+  public init(
+    title: TextState,
+    message: TextState? = nil,
+    buttons: [ButtonState<Action>] = []
+  ) {
+    self.init(
+      title: { title },
+      actions: {
+        for button in buttons {
+          button
+        }
+      },
+      message: message.map { message in { message } }
+    )
+  }
+}
+
+@available(iOS, introduced: 13, deprecated: 100000, renamed: "ConfirmationDialogState")
+@available(macOS, introduced: 12, unavailable)
+@available(tvOS, introduced: 13, deprecated: 100000, renamed: "ConfirmationDialogState")
+@available(watchOS, introduced: 6, deprecated: 100000, renamed: "ConfirmationDialogState")
+public typealias ActionSheetState<Action> = ConfirmationDialogState<Action>

--- a/SwiftNavigation.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SwiftNavigation.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "be6fe1eb8930cf8f1139cda59c7a45cad32a68ee9ca97713fad8b3a7cd0162ed",
   "pins" : [
     {
       "identity" : "combine-schedulers",


### PR DESCRIPTION
While 2.0 can have breaking changes, let's soften things a bit by reintroducing fully-deprecated alert/dialog initializers in the old style.