### PR TITLE
Rename ObservationToken to ObserveToken.

### DIFF
--- a/Sources/SwiftNavigation/Documentation.docc/SwiftNavigation.md
+++ b/Sources/SwiftNavigation/Documentation.docc/SwiftNavigation.md
@@ -37,7 +37,7 @@ SwiftUI, UIKit, AppKit, and even non-Apple platforms.
 ### Observing changes to state
 
 - ``observe(isolation:_:)-93yzu``
-- ``ObservationToken``
+- ``ObserveToken``
 
 ### Creating and sharing state
 

--- a/Sources/SwiftNavigation/Internal/Deprecations.swift
+++ b/Sources/SwiftNavigation/Internal/Deprecations.swift
@@ -1,3 +1,10 @@
+// MARK: - Deprecated after 2.1.0
+
+@available(*, unavailable, renamed: "ObserveToken")
+public typealias ObservationToken = ObserveToken
+
+// MARK: - Deprecated after 2.0.0
+
 extension AlertState {
   @available(*, deprecated, message: "Use 'init(title:actions:message:)' instead.")
   public init(

--- a/Sources/SwiftNavigation/Internal/Deprecations.swift
+++ b/Sources/SwiftNavigation/Internal/Deprecations.swift
@@ -1,6 +1,6 @@
 // MARK: - Deprecated after 2.1.0
 
-@available(*, unavailable, renamed: "ObserveToken")
+@available(*, deprecated, renamed: "ObserveToken")
 public typealias ObservationToken = ObserveToken
 
 // MARK: - Deprecated after 2.0.0

--- a/Sources/SwiftNavigation/Observe.swift
+++ b/Sources/SwiftNavigation/Observe.swift
@@ -58,7 +58,7 @@ import ConcurrencyExtras
   public func observe(
     isolation: (any Actor)? = #isolation,
     @_inheritActorContext _ apply: @escaping @Sendable () -> Void
-  ) -> ObservationToken {
+  ) -> ObserveToken {
     observe(isolation: isolation) { _ in apply() }
   }
 
@@ -74,7 +74,7 @@ import ConcurrencyExtras
   public func observe(
     isolation: (any Actor)? = #isolation,
     @_inheritActorContext _ apply: @escaping @Sendable (_ transaction: UITransaction) -> Void
-  ) -> ObservationToken {
+  ) -> ObserveToken {
     let actor = ActorProxy(base: isolation)
     return observe(
       apply,
@@ -110,8 +110,8 @@ public func observe(
   ) -> Void = {
     Task(operation: $1)
   }
-) -> ObservationToken {
-  let token = ObservationToken()
+) -> ObserveToken {
+  let token = ObserveToken()
   onChange(
     { [weak token] transaction in
       guard
@@ -144,12 +144,12 @@ private func onChange(
 ///
 /// When this token is deallocated it cancels the observation it was associated with. Store this
 /// token in another object to keep the observation alive. You can do with this with a set of
-/// ``ObservationToken``s and the ``store(in:)-1hsqo`` method:
+/// ``ObserveToken``s and the ``store(in:)-1hsqo`` method:
 ///
 /// ```swift
 /// class Coordinator {
 ///   let model = Model()
-///   var tokens: Set<ObservationToken> = []
+///   var tokens: Set<ObserveToken> = []
 ///
 ///   func start() {
 ///     observe { [weak self] in
@@ -159,7 +159,7 @@ private func onChange(
 ///   }
 /// }
 /// ```
-public final class ObservationToken: @unchecked Sendable, HashableObject {
+public final class ObserveToken: @unchecked Sendable, HashableObject {
   fileprivate let _isCancelled = LockIsolated(false)
   public var onCancel: @Sendable () -> Void
 
@@ -191,14 +191,14 @@ public final class ObservationToken: @unchecked Sendable, HashableObject {
   /// Stores this observation token instance in the specified collection.
   ///
   /// - Parameter collection: The collection in which to store this observation token.
-  public func store(in collection: inout some RangeReplaceableCollection<ObservationToken>) {
+  public func store(in collection: inout some RangeReplaceableCollection<ObserveToken>) {
     collection.append(self)
   }
 
   /// Stores this observation token instance in the specified set.
   ///
   /// - Parameter set: The set in which to store this observation token.
-  public func store(in set: inout Set<ObservationToken>) {
+  public func store(in set: inout Set<ObserveToken>) {
     set.insert(self)
   }
 }

--- a/Sources/UIKitNavigation/Bindings/UIColorWell.swift
+++ b/Sources/UIKitNavigation/Bindings/UIColorWell.swift
@@ -23,7 +23,7 @@
     ///   when the selected color changes.
     /// - Returns: A cancel token.
     @discardableResult
-    public func bind(selectedColor: UIBinding<UIColor?>) -> ObservationToken {
+    public func bind(selectedColor: UIBinding<UIColor?>) -> ObserveToken {
       bind(selectedColor, to: \.selectedColor, for: .valueChanged)
     }
   }

--- a/Sources/UIKitNavigation/Bindings/UIDatePicker.swift
+++ b/Sources/UIKitNavigation/Bindings/UIDatePicker.swift
@@ -23,7 +23,7 @@
     ///   selected date changes.
     /// - Returns: A cancel token.
     @discardableResult
-    public func bind(date: UIBinding<Date>) -> ObservationToken {
+    public func bind(date: UIBinding<Date>) -> ObserveToken {
       bind(date, to: \.date, for: .valueChanged)
     }
   }

--- a/Sources/UIKitNavigation/Bindings/UIPageControl.swift
+++ b/Sources/UIKitNavigation/Bindings/UIPageControl.swift
@@ -21,7 +21,7 @@
     ///   the current page changes.
     /// - Returns: A cancel token.
     @discardableResult
-    public func bind(currentPage: UIBinding<Int>) -> ObservationToken {
+    public func bind(currentPage: UIBinding<Int>) -> ObserveToken {
       bind(currentPage, to: \.currentPage, for: .valueChanged)
     }
   }

--- a/Sources/UIKitNavigation/Bindings/UISegmentedControl.swift
+++ b/Sources/UIKitNavigation/Bindings/UISegmentedControl.swift
@@ -40,7 +40,7 @@
       filePath: StaticString = #filePath,
       line: UInt = #line,
       column: UInt = #column
-    ) -> ObservationToken {
+    ) -> ObserveToken {
       let fileID = HashableStaticString(rawValue: fileID)
       let filePath = HashableStaticString(rawValue: filePath)
       return bind(

--- a/Sources/UIKitNavigation/Bindings/UISlider.swift
+++ b/Sources/UIKitNavigation/Bindings/UISlider.swift
@@ -22,7 +22,7 @@
     ///   value changes.
     /// - Returns: A cancel token.
     @discardableResult
-    public func bind(value: UIBinding<Float>) -> ObservationToken {
+    public func bind(value: UIBinding<Float>) -> ObserveToken {
       bind(value, to: \.value, for: .valueChanged)
     }
   }

--- a/Sources/UIKitNavigation/Bindings/UIStepper.swift
+++ b/Sources/UIKitNavigation/Bindings/UIStepper.swift
@@ -22,7 +22,7 @@
     ///   value changes.
     /// - Returns: A cancel token.
     @discardableResult
-    public func bind(value: UIBinding<Double>) -> ObservationToken {
+    public func bind(value: UIBinding<Double>) -> ObserveToken {
       bind(value, to: \.value, for: .valueChanged)
     }
   }

--- a/Sources/UIKitNavigation/Bindings/UISwitch.swift
+++ b/Sources/UIKitNavigation/Bindings/UISwitch.swift
@@ -23,7 +23,7 @@
     ///   state changes.
     /// - Returns: A cancel token.
     @discardableResult
-    public func bind(isOn: UIBinding<Bool>) -> ObservationToken {
+    public func bind(isOn: UIBinding<Bool>) -> ObserveToken {
       bind(isOn, to: \.isOn, for: .valueChanged) { control, isOn, transaction in
         control.setOn(isOn, animated: !transaction.uiKit.disablesAnimations)
       }

--- a/Sources/UIKitNavigation/Bindings/UITabBarController.swift
+++ b/Sources/UIKitNavigation/Bindings/UITabBarController.swift
@@ -11,7 +11,7 @@
       filePath: StaticString = #filePath,
       line: UInt = #line,
       column: UInt = #column
-    ) -> ObservationToken {
+    ) -> ObserveToken {
       let token = observe { [weak self] in
         guard let self else { return }
         guard let identifier = selectedTab.wrappedValue else {
@@ -41,25 +41,25 @@
           selectedTab.wrappedValue = controller.selectedTab?.identifier
         }
       }
-      let observationToken = ObservationToken {
+      let observeToken = ObserveToken {
         token.cancel()
         observation.invalidate()
       }
-      self.observationToken = observationToken
-      return observationToken
+      self.observeToken = observeToken
+      return observeToken
     }
 
-    private var observationToken: ObservationToken? {
+    private var observeToken: ObserveToken? {
       get {
-        objc_getAssociatedObject(self, Self.observationTokenKey) as? ObservationToken
+        objc_getAssociatedObject(self, Self.observeTokenKey) as? ObserveToken
       }
       set {
         objc_setAssociatedObject(
-          self, Self.observationTokenKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC
+          self, Self.observeTokenKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC
         )
       }
     }
 
-    private static let observationTokenKey = malloc(1)!
+    private static let observeTokenKey = malloc(1)!
   }
 #endif

--- a/Sources/UIKitNavigation/Bindings/UITextField.swift
+++ b/Sources/UIKitNavigation/Bindings/UITextField.swift
@@ -33,7 +33,7 @@
     ///   changes.
     /// - Returns: A cancel token.
     @discardableResult
-    public func bind(text: UIBinding<String>) -> ObservationToken {
+    public func bind(text: UIBinding<String>) -> ObserveToken {
       bind(UIBinding(text), to: \.text, for: .editingChanged)
     }
 
@@ -43,7 +43,7 @@
     ///   the attributed text changes.
     /// - Returns: A cancel token.
     @discardableResult
-    public func bind(attributedText: UIBinding<NSAttributedString>) -> ObservationToken {
+    public func bind(attributedText: UIBinding<NSAttributedString>) -> ObserveToken {
       bind(UIBinding(attributedText), to: \.attributedText, for: .editingChanged)
     }
 
@@ -53,7 +53,7 @@
     ///   the selected text range changes.
     /// - Returns: A cancel token.
     @discardableResult
-    public func bind(selection: UIBinding<UITextSelection?>) -> ObservationToken {
+    public func bind(selection: UIBinding<UITextSelection?>) -> ObserveToken {
       let editingChangedAction = UIAction { [weak self] _ in
         guard let self else { return }
         selection.wrappedValue = self.textSelection
@@ -70,7 +70,7 @@
           selection.wrappedValue = control.textSelection
         }
       }
-      let observationToken = ObservationToken { [weak self] in
+      let observeToken = ObserveToken { [weak self] in
         MainActor._assumeIsolated {
           self?.removeAction(editingChangedAction, for: [.editingChanged, .editingDidBegin])
           self?.removeAction(editingDidEndAction, for: .editingDidEnd)
@@ -78,8 +78,8 @@
         token.cancel()
         observation.invalidate()
       }
-      observationTokens[\UITextField.selectedTextRange] = observationToken
-      return observationToken
+      observeTokens[\UITextField.selectedTextRange] = observeToken
+      return observeToken
     }
 
     fileprivate var textSelection: UITextSelection? {
@@ -194,7 +194,7 @@
     @discardableResult
     public func bind<Value: Hashable>(
       focus: UIBinding<Value?>, equals value: Value
-    ) -> ObservationToken {
+    ) -> ObserveToken {
       self.focusToken?.cancel()
       let editingDidBeginAction = UIAction { _ in focus.wrappedValue = value }
       let editingDidEndAction = UIAction { _ in
@@ -214,7 +214,7 @@
           break
         }
       }
-      let outerToken = ObservationToken { [weak self] in
+      let outerToken = ObserveToken { [weak self] in
         MainActor._assumeIsolated {
           self?.removeAction(editingDidBeginAction, for: .editingDidBegin)
           self?.removeAction(editingDidEndAction, for: [.editingDidEnd, .editingDidEndOnExit])
@@ -276,12 +276,12 @@
     ///   automatically dismisses focus.
     /// - Returns: A cancel token.
     @discardableResult
-    public func bind(focus condition: UIBinding<Bool>) -> ObservationToken {
+    public func bind(focus condition: UIBinding<Bool>) -> ObserveToken {
       bind(focus: condition.toOptionalUnit, equals: Bool.Unit())
     }
 
-    private var focusToken: ObservationToken? {
-      get { objc_getAssociatedObject(self, Self.focusTokenKey) as? ObservationToken }
+    private var focusToken: ObserveToken? {
+      get { objc_getAssociatedObject(self, Self.focusTokenKey) as? ObserveToken }
       set {
         objc_setAssociatedObject(
           self, Self.focusTokenKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC

--- a/Sources/UIKitNavigation/Navigation/Presentation.swift
+++ b/Sources/UIKitNavigation/Navigation/Presentation.swift
@@ -20,7 +20,7 @@
       isPresented: UIBinding<Bool>,
       onDismiss: (() -> Void)? = nil,
       content: @escaping () -> UIViewController
-    ) -> ObservationToken {
+    ) -> ObserveToken {
       present(item: isPresented.toOptionalUnit, onDismiss: onDismiss) { _ in content() }
     }
 
@@ -42,7 +42,7 @@
       item: UIBinding<Item?>,
       onDismiss: (() -> Void)? = nil,
       content: @escaping (Item) -> UIViewController
-    ) -> ObservationToken {
+    ) -> ObserveToken {
       present(item: item, id: \.id, onDismiss: onDismiss, content: content)
     }
 
@@ -65,7 +65,7 @@
       item: UIBinding<Item?>,
       onDismiss: (() -> Void)? = nil,
       content: @escaping (UIBinding<Item>) -> UIViewController
-    ) -> ObservationToken {
+    ) -> ObserveToken {
       present(item: item, id: \.id, onDismiss: onDismiss, content: content)
     }
 
@@ -89,7 +89,7 @@
       id: KeyPath<Item, ID>,
       onDismiss: (() -> Void)? = nil,
       content: @escaping (Item) -> UIViewController
-    ) -> ObservationToken {
+    ) -> ObserveToken {
       present(item: item, id: id, onDismiss: onDismiss) {
         content($0.wrappedValue)
       }
@@ -116,7 +116,7 @@
       id: KeyPath<Item, ID>,
       onDismiss: (() -> Void)? = nil,
       content: @escaping (UIBinding<Item>) -> UIViewController
-    ) -> ObservationToken {
+    ) -> ObserveToken {
       destination(item: item, id: id) { $item in
         content($item)
       } present: { [weak self] child, transaction in
@@ -150,7 +150,7 @@
     public func navigationDestination(
       isPresented: UIBinding<Bool>,
       content: @escaping () -> UIViewController
-    ) -> ObservationToken {
+    ) -> ObserveToken {
       navigationDestination(item: isPresented.toOptionalUnit) { _ in content() }
     }
 
@@ -169,7 +169,7 @@
     public func navigationDestination<Item>(
       item: UIBinding<Item?>,
       content: @escaping (Item) -> UIViewController
-    ) -> ObservationToken {
+    ) -> ObserveToken {
       navigationDestination(item: item) {
         content($0.wrappedValue)
       }
@@ -191,7 +191,7 @@
     public func navigationDestination<Item>(
       item: UIBinding<Item?>,
       content: @escaping (UIBinding<Item>) -> UIViewController
-    ) -> ObservationToken {
+    ) -> ObserveToken {
       destination(item: item) { $item in
         content($item)
       } present: { [weak self] child, transaction in
@@ -246,7 +246,7 @@
         _ child: UIViewController,
         _ transaction: UITransaction
       ) -> Void
-    ) -> ObservationToken {
+    ) -> ObserveToken {
       destination(
         item: isPresented.toOptionalUnit,
         content: { _ in content() },
@@ -276,7 +276,7 @@
         _ child: UIViewController,
         _ transaction: UITransaction
       ) -> Void
-    ) -> ObservationToken {
+    ) -> ObserveToken {
       destination(
         item: item,
         id: { _ in nil },
@@ -314,7 +314,7 @@
         _ child: UIViewController,
         _ transaction: UITransaction
       ) -> Void
-    ) -> ObservationToken {
+    ) -> ObserveToken {
       destination(
         item: item,
         id: { $0[keyPath: id] },
@@ -336,7 +336,7 @@
         _ child: UIViewController,
         _ transaction: UITransaction
       ) -> Void
-    ) -> ObservationToken {
+    ) -> ObserveToken {
       let key = UIBindingIdentifier(item)
       return observe { [weak self] transaction in
         guard let self else { return }
@@ -409,7 +409,7 @@
     public func pushViewController(
       isPresented: UIBinding<Bool>,
       content: @escaping () -> UIViewController
-    ) -> ObservationToken {
+    ) -> ObserveToken {
       navigationDestination(isPresented: isPresented, content: content)
     }
 
@@ -423,7 +423,7 @@
     public func pushViewController<Item>(
       item: UIBinding<Item?>,
       content: @escaping (Item) -> UIViewController
-    ) -> ObservationToken {
+    ) -> ObserveToken {
       navigationDestination(item: item, content: content)
     }
 
@@ -438,7 +438,7 @@
     public func pushViewController<Item>(
       item: UIBinding<Item?>,
       content: @escaping (UIBinding<Item>) -> UIViewController
-    ) -> ObservationToken {
+    ) -> ObserveToken {
       navigationDestination(item: item, content: content)
     }
   }

--- a/Sources/UIKitNavigation/Observe.swift
+++ b/Sources/UIKitNavigation/Observe.swift
@@ -83,12 +83,12 @@
     ///
     /// ## Cancellation
     ///
-    /// The method returns an ``ObservationToken`` that can be used to cancel observation. For
+    /// The method returns an ``ObserveToken`` that can be used to cancel observation. For
     /// example, if you only want to observe while a view controller is visible, you can start
     /// observation in the `viewWillAppear` and then cancel observation in the `viewWillDisappear`:
     ///
     /// ```swift
-    /// var observation: ObservationToken?
+    /// var observation: ObserveToken?
     ///
     /// func viewWillAppear() {
     ///   super.viewWillAppear()
@@ -106,7 +106,7 @@
     ///   of a property changes.
     /// - Returns: A cancellation token.
     @discardableResult
-    public func observe(_ apply: @escaping @MainActor @Sendable () -> Void) -> ObservationToken {
+    public func observe(_ apply: @escaping @MainActor @Sendable () -> Void) -> ObserveToken {
       observe { _ in apply() }
     }
 
@@ -120,7 +120,7 @@
     @discardableResult
     public func observe(
       _ apply: @escaping @MainActor @Sendable (_ transaction: UITransaction) -> Void
-    ) -> ObservationToken {
+    ) -> ObserveToken {
       let token = SwiftNavigation.observe { transaction in
         MainActor._assumeIsolated {
           withUITransaction(transaction) {

--- a/Tests/SwiftNavigationTests/LifetimeTests.swift
+++ b/Tests/SwiftNavigationTests/LifetimeTests.swift
@@ -4,10 +4,10 @@
 
   final class LifetimeTests: XCTestCase {
     @MainActor
-    func testObservationToken() async {
+    func testObserveToken() async {
       let model = Model()
       var counts = [Int]()
-      var token: ObservationToken?
+      var token: ObserveToken?
       do {
         token = SwiftNavigation.observe {
           counts.append(model.count)


### PR DESCRIPTION
The new Swift notification API coming sometime in the future introduces its own `ObservationToken` type that will clash with ours. Really the name `ObservationToken` was a bit too general anyway, so let's preemptively rename it to something that will hopefully be a little less common.