### PR TITLE
Turn off Swift 6 mode.

### DIFF
--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -79,6 +79,18 @@ let package = Package(
         "UIKitNavigation"
       ]
     ),
-  ],
-  swiftLanguageVersions: [.v6]
+  ]
+  //, swiftLanguageModes: [.v6]
 )
+
+for target in package.targets {
+  target.swiftSettings = target.swiftSettings ?? []
+  target.swiftSettings!.append(contentsOf: [
+    .enableExperimentalFeature("StrictConcurrency")
+  ])
+  // target.swiftSettings?.append(
+  //   .unsafeFlags([
+  //     "-enable-library-evolution",
+  //   ])
+  // )
+}


### PR DESCRIPTION
While the library compiles just fine with no warnings in full Swift 6 mode, it has become annoying to keep up with the small changes introduced with each Xcode beta. So, we are turning of Swift 6 mode for now, and we will just enable it locally whenever we need to check for Swift 6 compatibility.