### PR TITLE
Dismiss presented controller when parent is nil

### DIFF
--- a/Examples/CaseStudiesTests/PresentationTests.swift
+++ b/Examples/CaseStudiesTests/PresentationTests.swift
@@ -437,21 +437,21 @@ final class PresentationTests: XCTestCase {
     let vc = VC()
     try await setUp(controller: vc)
 
-    withUITransaction(\.uiKit.disablesAnimations, true) {
-      vc.presentedChild = Model()
-    }
-    try await Task.sleep(for: .seconds(0.5))
+    vc.presentedChild = Model()
+    await assertEventuallyNotNil(vc.presentedViewController)
 
-    withUITransaction(\.uiKit.disablesAnimations, true) {
-      vc.presentedChild?.isPushed = true
-    }
-    try await Task.sleep(for: .seconds(0.5))
+    vc.presentedChild?.isPushed = true
+    await assertEventuallyEqual(
+      (vc.presentedViewController as? UINavigationController)?.viewControllers.count,
+      2
+    )
 
-    withUITransaction(\.uiKit.disablesAnimations, false) {
-      vc.presentedChild?.isPushed = false
-    }
-    try await Task.sleep(for: .seconds(1))
-
+    try await Task.sleep(for: .seconds(0.3))
+    vc.presentedChild?.isPushed = false
+    await assertEventuallyEqual(
+      (vc.presentedViewController as? UINavigationController)?.viewControllers.count,
+      1
+    )
     await assertEventuallyNotNil(vc.presentedChild)
   }
 }

--- a/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "808eb8e1d07661e8b57a786176eca2c0701a6e550ecfe221b0585e8b058c8ebd",
+  "originHash" : "d0f789afc5a07ea2d162d8405e7e2c61a4303155472804d542723dbcf4eba9e7",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -67,7 +67,7 @@
     {
       "identity" : "swift-docc-plugin",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-docc-plugin",
+      "location" : "https://github.com/swiftlang/swift-docc-plugin",
       "state" : {
         "revision" : "26ac5758409154cc448d7ab82389c520fa8a8247",
         "version" : "1.3.0"

--- a/Sources/UIKitNavigation/Navigation/Presentation.swift
+++ b/Sources/UIKitNavigation/Navigation/Presentation.swift
@@ -452,7 +452,8 @@
       //     deinit alongside it on the main thread. If we use this other places we should force it
       //     to be a UIViewController as well, to ensure this functionality.
       MainActor._assumeIsolated {
-        self.controller?.dismiss(animated: false)
+        guard let controller, controller.parent == nil else { return }
+        controller.dismiss(animated: false)
       }
     }
     init(_ controller: UIViewController, id presentationID: AnyHashable? = nil) {


### PR DESCRIPTION
Created to fix #205. 
Added a condition to the process introduced in #192 to close children when the parent controller disappears.