### PR TITLE
Fix NavigationStackController pop animations

### DIFF
--- a/Sources/UIKitNavigation/Navigation/NavigationStackController.swift
+++ b/Sources/UIKitNavigation/Navigation/NavigationStackController.swift
@@ -90,9 +90,9 @@
         } else if difference.count == 1,
           case .remove(newPath.count, _, nil) = difference.first
         {
-          popViewController(animated: transaction.uiKit.disablesAnimations)
+          popViewController(animated: !transaction.uiKit.disablesAnimations)
         } else if difference.insertions.isEmpty, newPath.isEmpty {
-          popToRootViewController(animated: transaction.uiKit.disablesAnimations)
+          popToRootViewController(animated: !transaction.uiKit.disablesAnimations)
         } else if difference.insertions.isEmpty,
           case let offsets = difference.removals.map(\.offset),
           let first = offsets.first,


### PR DESCRIPTION
Fixed popping view controllers by modifying the path is not animating correctly due to a logic error.