### PR TITLE
Disable perception tracking in UI/NS views/controllers representables

### DIFF
--- a/Sources/AppKitNavigation/SwiftUI/Representable.swift
+++ b/Sources/AppKitNavigation/SwiftUI/Representable.swift
@@ -11,7 +11,9 @@
   >: NSViewControllerRepresentable {
     private let base: NSViewControllerType
     public init(_ base: () -> NSViewControllerType) {
-      self.base = base()
+      self.base = _PerceptionLocals.$skipPerceptionChecking.withValue(true) {
+        base()
+      }
     }
     public func makeNSViewController(context _: Context) -> NSViewControllerType { base }
     public func updateNSViewController(_: NSViewControllerType, context _: Context) {}
@@ -24,7 +26,9 @@
   public struct NSViewRepresenting<NSViewType: NSView>: NSViewRepresentable {
     private let base: NSViewType
     public init(_ base: () -> NSViewType) {
-      self.base = base()
+      self.base = _PerceptionLocals.$skipPerceptionChecking.withValue(true) {
+        base()
+      }
     }
     public func makeNSView(context _: Context) -> NSViewType { base }
     public func updateNSView(_: NSViewType, context _: Context) {}

--- a/Sources/UIKitNavigation/SwiftUI/Representable.swift
+++ b/Sources/UIKitNavigation/SwiftUI/Representable.swift
@@ -14,7 +14,9 @@
   >: UIViewControllerRepresentable {
     private let base: UIViewControllerType
     public init(_ base: () -> UIViewControllerType) {
-      self.base = base()
+      self.base = _PerceptionLocals.$skipPerceptionChecking.withValue(true) {
+        base()
+      }
     }
     public func makeUIViewController(context _: Context) -> UIViewControllerType { base }
     public func updateUIViewController(_: UIViewControllerType, context _: Context) {}
@@ -27,7 +29,9 @@
   public struct UIViewRepresenting<UIViewType: UIView>: UIViewRepresentable {
     private let base: UIViewType
     public init(_ base: () -> UIViewType) {
-      self.base = base()
+      self.base = _PerceptionLocals.$skipPerceptionChecking.withValue(true) {
+        base()
+      }
     }
     public func makeUIView(context _: Context) -> UIViewType { base }
     public func updateUIView(_: UIViewType, context _: Context) {}

--- a/Tests/UIKitNavigationTests/ObserveTests.swift
+++ b/Tests/UIKitNavigationTests/ObserveTests.swift
@@ -1,7 +1,9 @@
 #if canImport(UIKit)
   import UIKitNavigation
+import SwiftUI
   import XCTest
 
+@available(iOS 16.0, *)
   class ObserveTests: XCTestCase {
     @MainActor
     func testCompiles() {
@@ -11,5 +13,35 @@
       }
       XCTAssertEqual(count, 1)
     }
+
+    @MainActor
+    func testPerceptionCheckingInNavigationStackController() async throws {
+      struct RootView: View {
+        @UIBindable var model = AppModel()
+        var body: some View {
+          UIViewControllerRepresenting {
+            NavigationStackController(path: $model.path) {
+              UIViewController()
+            }
+          }
+        }
+      }
+
+      try await render(RootView())
+    }
+
+    @MainActor
+    private func render(_ view: some View) async throws  {
+      let image = ImageRenderer(content: view).cgImage
+      _ = image
+      try await Task.sleep(for: .seconds(0.1))
+    }
   }
+
+//extension NavigationStackController
+
+@Perceptible
+private class AppModel: HashableObject {
+  var path: [Int] = []
+}
 #endif

--- a/Tests/UIKitNavigationTests/ObserveTests.swift
+++ b/Tests/UIKitNavigationTests/ObserveTests.swift
@@ -1,6 +1,5 @@
 #if canImport(UIKit)
   import UIKitNavigation
-  import SwiftUI
   import XCTest
 
   class ObserveTests: XCTestCase {

--- a/Tests/UIKitNavigationTests/ObserveTests.swift
+++ b/Tests/UIKitNavigationTests/ObserveTests.swift
@@ -1,9 +1,8 @@
 #if canImport(UIKit)
   import UIKitNavigation
-import SwiftUI
+  import SwiftUI
   import XCTest
 
-@available(iOS 16.0, *)
   class ObserveTests: XCTestCase {
     @MainActor
     func testCompiles() {
@@ -13,35 +12,5 @@ import SwiftUI
       }
       XCTAssertEqual(count, 1)
     }
-
-    @MainActor
-    func testPerceptionCheckingInNavigationStackController() async throws {
-      struct RootView: View {
-        @UIBindable var model = AppModel()
-        var body: some View {
-          UIViewControllerRepresenting {
-            NavigationStackController(path: $model.path) {
-              UIViewController()
-            }
-          }
-        }
-      }
-
-      try await render(RootView())
-    }
-
-    @MainActor
-    private func render(_ view: some View) async throws  {
-      let image = ImageRenderer(content: view).cgImage
-      _ = image
-      try await Task.sleep(for: .seconds(0.1))
-    }
   }
-
-//extension NavigationStackController
-
-@Perceptible
-private class AppModel: HashableObject {
-  var path: [Int] = []
-}
 #endif

--- a/Tests/UIKitNavigationTests/ViewControllerRepresentingTests.swift
+++ b/Tests/UIKitNavigationTests/ViewControllerRepresentingTests.swift
@@ -3,7 +3,7 @@
   import SwiftUI
   import XCTest
 
-  @available(iOS 16.0, *)
+@available(iOS 16, tvOS 16, *)
   class ViewControllerRepresentingTests: XCTestCase {
     @MainActor
     func testPerceptionCheckingInNavigationStackController() async throws {

--- a/Tests/UIKitNavigationTests/ViewControllerRepresentingTests.swift
+++ b/Tests/UIKitNavigationTests/ViewControllerRepresentingTests.swift
@@ -1,0 +1,36 @@
+#if canImport(UIKit)
+  import UIKitNavigation
+  import SwiftUI
+  import XCTest
+
+  @available(iOS 16.0, *)
+  class ViewControllerRepresentingTests: XCTestCase {
+    @MainActor
+    func testPerceptionCheckingInNavigationStackController() async throws {
+      struct RootView: View {
+        @UIBindable var model = AppModel()
+        var body: some View {
+          UIViewControllerRepresenting {
+            NavigationStackController(path: $model.path) {
+              UIViewController()
+            }
+          }
+        }
+      }
+
+      try await render(RootView())
+    }
+
+    @MainActor
+    private func render(_ view: some View) async throws {
+      let image = ImageRenderer(content: view).cgImage
+      _ = image
+      try await Task.sleep(for: .seconds(0.1))
+    }
+  }
+
+  @Perceptible
+  private class AppModel: HashableObject {
+    var path: [Int] = []
+  }
+#endif

--- a/Tests/UIKitNavigationTests/ViewControllerRepresentingTests.swift
+++ b/Tests/UIKitNavigationTests/ViewControllerRepresentingTests.swift
@@ -3,7 +3,7 @@
   import SwiftUI
   import XCTest
 
-@available(iOS 16, tvOS 16, *)
+@available(iOS 16, tvOS 16, watchOS 9, *)
   class ViewControllerRepresentingTests: XCTestCase {
     @MainActor
     func testPerceptionCheckingInNavigationStackController() async throws {

--- a/Tests/UIKitNavigationTests/ViewControllerRepresentingTests.swift
+++ b/Tests/UIKitNavigationTests/ViewControllerRepresentingTests.swift
@@ -1,9 +1,9 @@
-#if canImport(UIKit)
+#if canImport(UIKit) && !os(watchOS)
   import UIKitNavigation
   import SwiftUI
   import XCTest
 
-@available(iOS 16, tvOS 16, watchOS 9, *)
+  @available(iOS 16, tvOS 16, *)
   class ViewControllerRepresentingTests: XCTestCase {
     @MainActor
     func testPerceptionCheckingInNavigationStackController() async throws {


### PR DESCRIPTION
Disable perception tracking when creating UI/NS views/controllers in a representable.