### PR TITLE
Prefer scoped import over `@_implementationOnly`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -97,7 +97,8 @@ let package = Package(
 for target in package.targets {
   target.swiftSettings = target.swiftSettings ?? []
   target.swiftSettings!.append(contentsOf: [
-    .enableExperimentalFeature("StrictConcurrency")
+    .enableExperimentalFeature("AccessLevelOnImport"),
+    .enableExperimentalFeature("StrictConcurrency"),
   ])
   // target.swiftSettings?.append(
   //   .unsafeFlags([

--- a/Sources/UIKitNavigation/Navigation/Presentation.swift
+++ b/Sources/UIKitNavigation/Navigation/Presentation.swift
@@ -2,7 +2,11 @@
   import IssueReporting
   @_spi(Internals) import SwiftNavigation
   import UIKit
-  @_implementationOnly import UIKitNavigationShim
+  #if compiler(>=5.10)
+    private import UIKitNavigationShim
+  #else
+    @_implementationOnly import UIKitNavigationShim
+  #endif
 
   extension UIViewController {
     /// Presents a view controller modally when a binding to a Boolean value you provide is true.


### PR DESCRIPTION
The `@_implementationOnly` attribute is effectively deprecated in favor of scoped imports.