### PR TITLE
Remove `onDismiss` closure call when dismissing presentedViewController

### DIFF
--- a/Sources/UIKitNavigation/Navigation/Presentation.swift
+++ b/Sources/UIKitNavigation/Navigation/Presentation.swift
@@ -123,7 +123,6 @@
         guard let self else { return }
         if presentedViewController != nil {
           self.dismiss(animated: !transaction.uiKit.disablesAnimations) {
-            onDismiss?()
             self.present(child, animated: !transaction.uiKit.disablesAnimations)
           }
         } else {


### PR DESCRIPTION
`onDismiss` closure is being called even when the presentedViewController is dismissed.
As far as I understand, the onDismiss closure should only be called when the ViewController passed as the content closure is dismissed.