### PR TITLE
Support eager navigation destination resolution

### DIFF
--- a/Examples/CaseStudies/UIKit/ErasedNavigationStackController.swift
+++ b/Examples/CaseStudies/UIKit/ErasedNavigationStackController.swift
@@ -81,6 +81,10 @@ private class NumberFeatureViewController: UIViewController {
     self.number = number
     super.init(nibName: nil, bundle: nil)
     title = "Feature \(number)"
+
+    navigationDestination(for: String.self) { string in
+      StringFeatureViewController(string: string)
+    }
   }
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
@@ -88,10 +92,6 @@ private class NumberFeatureViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     view.backgroundColor = .systemBackground
-
-    navigationDestination(for: String.self) { string in
-      StringFeatureViewController(string: string)
-    }
 
     let numberButton = UIButton(
       type: .system,
@@ -137,6 +137,10 @@ private class StringFeatureViewController: UIViewController {
     self.string = string
     super.init(nibName: nil, bundle: nil)
     title = "Feature '\(string)'"
+
+    navigationDestination(for: Bool.self) { bool in
+      BoolFeatureViewController(bool: bool)
+    }
   }
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
@@ -144,10 +148,6 @@ private class StringFeatureViewController: UIViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
     view.backgroundColor = .systemBackground
-
-    navigationDestination(for: Bool.self) { bool in
-      BoolFeatureViewController(bool: bool)
-    }
 
     let numberButton = UIButton(
       type: .system,

--- a/Examples/CaseStudiesTests/NavigationPathTests.swift
+++ b/Examples/CaseStudiesTests/NavigationPathTests.swift
@@ -484,6 +484,32 @@ final class NavigationPathTests: XCTestCase {
   }
 
   @MainActor
+  func testPushMultipleFeaturesAtOnce_InitRegisteredNavigationDestination() async throws {
+    @UIBinding var path = UINavigationPath()
+    let nav = NavigationStackController(path: $path) {
+      InitRootViewController()
+    }
+    try await setUp(controller: nav)
+
+    let root = nav.viewControllers[0]
+    withUITransaction(\.uiKit.disablesAnimations, true) {
+      root.traitCollection.push(value: 2)
+      root.traitCollection.push(value: "Hello")
+      root.traitCollection.push(value: true)
+    }
+
+    await assertEventuallyEqual(nav.viewControllers.count, 4, timeout: 2)
+    await assertEventuallyNoDifference(
+      nav.values,
+      [2, "Hello", true] as [AnyHashable]
+    )
+    await assertEventuallyNoDifference(
+      path.elements,
+      [.eager(2), .eager("Hello"), .eager(true)]
+    )
+  }
+
+  @MainActor
   func testRegisterNavigationDestinationTypeMultipleTimes_LastOneWins() async throws {
     @UIBinding var path = UINavigationPath()
     let nav = NavigationStackController(path: $path) {
@@ -622,6 +648,43 @@ private final class BoolViewController: UIViewController, _ValueViewController {
   }
   override func viewDidLoad() {
     super.viewDidLoad()
+  }
+}
+
+private final class InitRootViewController: UIViewController {
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    navigationDestination(for: Int.self) { int in
+      InitIntegerViewController(value: int)
+    }
+  }
+}
+
+private final class InitIntegerViewController: UIViewController, _ValueViewController {
+  let value: Int
+  init(value: Int) {
+    self.value = value
+    super.init(nibName: nil, bundle: nil)
+    navigationDestination(for: String.self) { string in
+      InitStringViewController(value: string)
+    }
+  }
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}
+
+private final class InitStringViewController: UIViewController, _ValueViewController {
+  let value: String
+  init(value: String) {
+    self.value = value
+    super.init(nibName: nil, bundle: nil)
+    navigationDestination(for: Bool.self) { bool in
+      BoolViewController(value: bool)
+    }
+  }
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
   }
 }
 

--- a/Examples/CaseStudiesTests/NavigationPathTests.swift
+++ b/Examples/CaseStudiesTests/NavigationPathTests.swift
@@ -510,6 +510,33 @@ final class NavigationPathTests: XCTestCase {
   }
 
   @MainActor
+  func testDeepLink_InitRegisteredNavigationDestination() async throws {
+    var initialPath = UINavigationPath()
+    initialPath.append(1)
+    initialPath.append("Hello")
+    initialPath.append(true)
+    @UIBinding var path = initialPath
+
+    let nav = NavigationStackController(path: $path) {
+      UIViewController()
+    }
+    nav.navigationDestination(for: Int.self) { int in
+      InitIntegerViewController(value: int)
+    }
+    try await setUp(controller: nav)
+
+    await assertEventuallyEqual(nav.viewControllers.count, 4, timeout: 2)
+    await assertEventuallyNoDifference(
+      nav.values,
+      [1, "Hello", true] as [AnyHashable]
+    )
+    await assertEventuallyNoDifference(
+      path.elements,
+      [.eager(1), .eager("Hello"), .eager(true)]
+    )
+  }
+
+  @MainActor
   func testRegisterNavigationDestinationTypeMultipleTimes_LastOneWins() async throws {
     @UIBinding var path = UINavigationPath()
     let nav = NavigationStackController(path: $path) {

--- a/Sources/UIKitNavigation/Navigation/NavigationStackController.swift
+++ b/Sources/UIKitNavigation/Navigation/NavigationStackController.swift
@@ -338,14 +338,19 @@
         )
         return
       }
-      stackController.path.append(.lazy(.element(value)))
+      withUITransaction(\.stackController, stackController) {
+        stackController.path.append(.lazy(.element(value)))
+      }
     }
 
     public func navigationDestination<D: Hashable>(
       for data: D.Type,
       destination: @escaping (D) -> UIViewController
     ) {
-      guard let navigationController = navigationController ?? self as? UINavigationController
+      guard
+        let navigationController = UITransaction.current.stackController
+          ?? navigationController
+          ?? self as? UINavigationController
       else {
         reportIssue(
           """
@@ -441,5 +446,16 @@
         )
       }
     }
+  }
+
+  private extension UITransaction {
+    var stackController: NavigationStackController? {
+      get { self[NavigationStackControllerKey.self] }
+      set { self[NavigationStackControllerKey.self] = newValue }
+    }
+  }
+
+  private enum NavigationStackControllerKey: UITransactionKey {
+    static let defaultValue: NavigationStackController? = nil
   }
 #endif

--- a/Sources/UIKitNavigation/Navigation/NavigationStackController.swift
+++ b/Sources/UIKitNavigation/Navigation/NavigationStackController.swift
@@ -168,7 +168,9 @@
       guard
         let destinationType = navigationID.elementType,
         let destination = destinations[DestinationType(destinationType)],
-        let (viewController, element) = destination(navigationID)
+        let (viewController, element) = withUITransaction(\.stackController, self, {
+          destination(navigationID)
+        })
       else {
         return nil
       }
@@ -357,9 +359,7 @@
         )
         return
       }
-      withUITransaction(\.stackController, stackController) {
-        stackController.path.append(.lazy(.element(value)))
-      }
+      stackController.path.append(.lazy(.element(value)))
     }
 
     public func navigationDestination<D: Hashable>(


### PR DESCRIPTION
Currently we steer folks to using `viewDidLoad` for all observation, but this laziness can lead to issues with deep-linking in type-erased navigation stacks, where a destination may declare a sub-destination in its `viewDidLoad`, causing the first drill-down to occur lazily over multiple animated steps instead of a single one. This behavior can be seen in the type-erased navigation case study in the repository.

This PR is a proof of concept to show that the library can populate a "current navigation stack" in the UI transaction so that a destination's initializer can declare its dependent destinations, fixing the case study behavior.

An idea brought up by @iampatbrown.