### PR TITLE
Fix onDismiss not called when view controller is explicitly dismissed

### DIFF
--- a/Examples/CaseStudiesTests/PresentationTests.swift
+++ b/Examples/CaseStudiesTests/PresentationTests.swift
@@ -43,6 +43,27 @@ final class PresentationTests: XCTestCase {
   }
 
   @MainActor
+  func testPresents_Dismissal() async throws {
+    let vc = BasicViewController()
+    try await setUp(controller: vc)
+
+    await assertEventuallyNil(vc.presentedViewController)
+
+    withUITransaction(\.uiKit.disablesAnimations, true) {
+      vc.model.isPresented = true
+    }
+    await assertEventuallyNotNil(vc.presentedViewController)
+    await assertEventuallyEqual(vc.isPresenting, true)
+
+    withUITransaction(\.uiKit.disablesAnimations, true) {
+      vc.presentedViewController?.dismiss(animated: false)
+    }
+    await assertEventuallyNil(vc.presentedViewController)
+    await assertEventuallyEqual(vc.model.isPresented, false)
+    await assertEventuallyEqual(vc.isPresenting, false)
+  }
+
+  @MainActor
   func testPresents_TraitDismissal() async throws {
     let vc = BasicViewController()
     try await setUp(controller: vc)
@@ -53,12 +74,14 @@ final class PresentationTests: XCTestCase {
       vc.model.isPresented = true
     }
     await assertEventuallyNotNil(vc.presentedViewController)
+    await assertEventuallyEqual(vc.isPresenting, true)
 
     withUITransaction(\.uiKit.disablesAnimations, true) {
       vc.presentedViewController?.traitCollection.dismiss()
     }
     await assertEventuallyNil(vc.presentedViewController)
     await assertEventuallyEqual(vc.model.isPresented, false)
+    await assertEventuallyEqual(vc.isPresenting, false)
   }
 
   @MainActor

--- a/Sources/UIKitNavigation/Navigation/Presentation.swift
+++ b/Sources/UIKitNavigation/Navigation/Presentation.swift
@@ -445,13 +445,15 @@
 
   @MainActor
   private class Presented {
-    weak var controller: UIViewController?
+    var controller: UIViewController?
     let presentationID: AnyHashable?
     deinit {
       // NB: This can only be assumed because it is held in a UIViewController and is guaranteed to
       //     deinit alongside it on the main thread. If we use this other places we should force it
       //     to be a UIViewController as well, to ensure this functionality.
       MainActor._assumeIsolated {
+        defer { controller = nil }
+
         guard let controller, controller.parent == nil else { return }
         controller.dismiss(animated: false)
       }


### PR DESCRIPTION
Looks like present(item:content:) function in UIKit does not successfully call onDismiss as one would expect. I'm not seeing a print statement when I do this:

```swift
// Using item parameter
present(item: $model.destination.alert, id: \.self, onDismiss: {
  print("Yay!!!")
}) { message in
  let alert = UIAlertController(
    title: "This is an alert",
    message: message,
    preferredStyle: .alert
  )
  alert.addAction(UIAlertAction(title: "OK", style: .default))
  return alert
}

// Using isPresented parameter
present(isPresented: UIBinding($model.destination.alert), onDismiss: {
  print("Yay!!!")
}) { //message in
  let alert = UIAlertController(
    title: "This is an alert",
    message: "LOL",
    preferredStyle: .alert
  )
  alert.addAction(UIAlertAction(title: "OK", style: .default))
  return alert
}
```

Going through breakpoints, it appears that controller is always nil: https://github.com/pointfreeco/swift-navigation/blob/main/Sources/UIKitNavigation/Navigation/Presentation.swift#L377. I find it strange because I the debugger does at some point set the dict with a value: https://github.com/pointfreeco/swift-navigation/blob/main/Sources/UIKitNavigation/Navigation/Presentation.swift#L365. Dismissal was working properly, and I have a better understanding of how caching works after spending a few minutes reading the code, so it didn't look like the problem resided there.

The next thing that stood out to me was the weakified controller property in `Presented`, and that the dictionary's controller properties were being immediately deallocated. Removing `weak` will certainly fix this, and I explicitly deallocate it in the `deinit` to mimic the `weak` behavior.