### PR TITLE
Fix: delegate's methods of the subclass of NavigationStackController are not called

### DIFF
--- a/Sources/UIKitNavigation/Navigation/NavigationStackController.swift
+++ b/Sources/UIKitNavigation/Navigation/NavigationStackController.swift
@@ -194,9 +194,23 @@
       weak var base: (any UINavigationControllerDelegate)?
 
       override func responds(to aSelector: Selector!) -> Bool {
-        aSelector == #selector(navigationController(_:didShow:animated:))
+        #if !os(tvOS) && !os(watchOS)
+        aSelector == #selector(navigationController(_:willShow:animated:))
+          || aSelector == #selector(navigationController(_:didShow:animated:))
+          || aSelector == #selector(navigationControllerSupportedInterfaceOrientations(_:))
+          || aSelector == #selector(navigationControllerPreferredInterfaceOrientationForPresentation(_:))
+          || aSelector == #selector(navigationController(_:interactionControllerFor:))
+          || aSelector == #selector(navigationController(_:animationControllerFor:from:to:))
           || MainActor._assumeIsolated { base?.responds(to: aSelector) }
             ?? false
+        #else
+        aSelector == #selector(navigationController(_:willShow:animated:))
+          || aSelector == #selector(navigationController(_:didShow:animated:))
+          || aSelector == #selector(navigationController(_:interactionControllerFor:))
+          || aSelector == #selector(navigationController(_:animationControllerFor:from:to:))
+          || MainActor._assumeIsolated { base?.responds(to: aSelector) }
+            ?? false
+        #endif
       }
 
       func navigationController(


### PR DESCRIPTION
As shown below, an instance of NavigationDelegate is set to `delegate` property in a subclass of NavigationStackController.

```swift
ExampleNavigationStackController: NavigationStackController {
  private let navigationDelegate: NavigationDelegate

  public override func viewDidLoad() {
    super.viewDidLoad()
    delegate = navigationDelegate
  }
}

class NavigationDelegate: NSObject, UINavigationControllerDelegate {
  func navigationController(_ navigationController: UINavigationController, willShow viewController: UIViewController, animated: Bool) {
    // ... not called
  }

  func navigationController(_ navigationController: UINavigationController, didShow viewController: UIViewController, animated: Bool) {
    // ... called
  }
}
```

However, `navigationController(_:willShow:animated:)` is not called, while `navigationController(_:didShow:animated:)` is called.

In the viewDidLoad method of NavigationStackController, an instance of PathDelegate is assigned to `delegate` property. At this point, an implementation check using `responds(to:)` is performed. However, since NavigationDelegate has not yet been set, `navigationController(_:willShow:animated:)` is determined to be unimplemented.

To address this, I added the missing methods to `responds(to:)`.