### PR TITLE
Promote `Void?` bindings to `Bool` via dynamic member lookup

### DIFF
--- a/Sources/SwiftNavigation/Binding.swift
+++ b/Sources/SwiftNavigation/Binding.swift
@@ -1,23 +1,56 @@
 #if canImport(SwiftUI)
+  import IssueReporting
   import SwiftUI
 
   extension Binding {
     /// Creates a binding by projecting the base optional value to a Boolean value.
     ///
-    /// Writing `false` to the binding will `nil` out the base value. Writing `true` does nothing.
+    /// Writing `false` to the binding will `nil` out the base value. Writing `true` produces a
+    /// runtime warning.
     ///
     /// - Parameter base: A value to project to a Boolean value.
-    public init<V>(_ base: Binding<V?>) where Value == Bool {
-      self = base._isPresent
+    public init<V>(
+      _ base: Binding<V?>,
+      fileID: StaticString = #fileID,
+      filePath: StaticString = #filePath,
+      line: UInt = #line,
+      column: UInt = #column
+    ) where Value == Bool {
+      self = base[
+        fileID: HashableStaticString(rawValue: fileID),
+        filePath: HashableStaticString(rawValue: filePath),
+        line: line,
+        column: column
+      ]
     }
   }
 
   extension Optional {
-    fileprivate var _isPresent: Bool {
+    fileprivate subscript(
+      fileID fileID: HashableStaticString,
+      filePath filePath: HashableStaticString,
+      line line: UInt,
+      column column: UInt
+    ) -> Bool {
       get { self != nil }
       set {
-        guard !newValue else { return }
-        self = nil
+        if newValue {
+          reportIssue(
+            """
+            Boolean presentation binding attempted to write 'true' to a generic 'Binding<Item?>' \
+            (i.e., 'Binding<\(Wrapped.self)?>').
+
+            This is not a valid thing to do, as there is no way to convert 'true' to a new \
+            instance of '\(Wrapped.self)'.
+            """,
+            fileID: fileID.rawValue,
+            filePath: filePath.rawValue,
+            line: line,
+            column: column
+          )
+        } else {
+          self = nil
+        }
       }
     }
   }

--- a/Sources/SwiftNavigation/Documentation.docc/Extensions/UIBinding.md
+++ b/Sources/SwiftNavigation/Documentation.docc/Extensions/UIBinding.md
@@ -8,6 +8,7 @@
 - ``init(_:)-1p53m``
 - ``init(_:)-3ww0m``
 - ``init(_:)-9wed9``
+- ``init(_:fileID:filePath:line:column:)``
 - ``init(projectedValue:)``
 - ``constant(_:)``
 
@@ -17,7 +18,9 @@
 - ``projectedValue``
 - ``subscript(dynamicMember:)-61aos``
 - ``subscript(dynamicMember:)-95b8x``
+- ``subscript(dynamicMember:)-xef5``
 - ``subscript(dynamicMember:)-lmkz``
+- ``subscript(dynamicMember:)-63hti``
 
 ### Managing changes
 

--- a/Sources/SwiftNavigation/UIBinding.swift
+++ b/Sources/SwiftNavigation/UIBinding.swift
@@ -441,6 +441,17 @@ public struct UIBinding<Value>: Sendable {
     return open(location)
   }
 
+  /// Returns a Boolean binding to a case of a given case key path with no associated value.
+  ///
+  /// - Parameter keyPath: A case key path to a case with no associated value.
+  /// - Returns: A new binding.
+  public subscript<V: CasePathable>(
+    dynamicMember keyPath: KeyPath<V.AllCasePaths, AnyCasePath<V, Void>>
+  ) -> UIBinding<Bool>
+  where Value == V? {
+    UIBinding<Bool>(self[dynamicMember: keyPath])
+  }
+
   /// Specifies a transaction for the binding.
   ///
   /// - Parameter transaction: An instance of a ``UITransaction``.

--- a/Sources/SwiftUINavigation/Binding.swift
+++ b/Sources/SwiftUINavigation/Binding.swift
@@ -29,6 +29,21 @@
       self[keyPath]
     }
 
+    /// Returns a binding to a Boolean for a given case key path to a case without an associated
+    /// value.
+    ///
+    /// Useful for driving navigation off an optional enumeration of destinations for navigation
+    /// APIs that take a Boolean binding.
+    ///
+    /// - Parameter keyPath: A case key path to a specific associated value.
+    /// - Returns: A new binding.
+    public subscript<Enum: CasePathable>(
+      dynamicMember keyPath: KeyPath<Enum.AllCasePaths, AnyCasePath<Enum, Void>>
+    ) -> Binding<Bool>
+    where Value == Enum? {
+      Binding<Bool>(self[keyPath])
+    }
+
     /// Creates a binding by projecting the base value to an unwrapped value.
     ///
     /// Useful for producing non-optional bindings from optional ones.

--- a/Sources/SwiftUINavigation/Documentation.docc/Articles/Bindings.md
+++ b/Sources/SwiftUINavigation/Documentation.docc/Articles/Bindings.md
@@ -70,6 +70,7 @@ struct SignInView: View {
 ### Dynamic case lookup
 
 - ``SwiftUI/Binding/subscript(dynamicMember:)-9abgy``
+- ``SwiftUI/Binding/subscript(dynamicMember:)-4i40p``
 - ``SwiftUI/Binding/subscript(dynamicMember:)-8vc80``
 
 ### Unwrapping bindings

--- a/Tests/SwiftNavigationTests/UIBindingTests.swift
+++ b/Tests/SwiftNavigationTests/UIBindingTests.swift
@@ -44,6 +44,19 @@ final class UIBindingTests: XCTestCase {
     count = 1729
     XCTAssertEqual(count, 1729)
     XCTAssertEqual(unwrappedCountBinding.wrappedValue, 1729)
+
+    XCTExpectFailure {
+      let isCountPresent: UIBinding<Bool> = UIBinding($count)
+      isCountPresent.wrappedValue = true
+    } issueMatcher: {
+      $0.compactDescription == """
+        failed - Boolean presentation binding attempted to write 'true' to a generic 'UIBinding<Item?>' \
+        (i.e., 'UIBinding<Int?>').
+        
+        This is not a valid thing to do, as there is no way to convert 'true' to a new instance of \
+        'Int'.
+        """
+    }
   }
 
   func testOperationToOptional() {


### PR DESCRIPTION
We have an explicit initializer for this conversion, but it's not super discoverable and it's generalized to all optionals. We can make a shorthand for `Void` payloads, which simplifies presentation:

```diff
-.sheet(isPresented: Binding($destination.sheet)) {
+.sheet(isPresented: $destination.sheet) {
   // ...
 }
```

Other changes:

- `SwiftUI.Binding<Bool>(Binding<Optional>)`'s implementation strayed slightly from UIKit's `UIBinding` implementation, where issues were not reported. This is fixed.

- Added missing documentation.