### PR TITLE
Expose UITransaction APIs under @_spi

### DIFF
--- a/Sources/AppKitNavigation/AppKitAnimation.swift
+++ b/Sources/AppKitNavigation/AppKitAnimation.swift
@@ -31,7 +31,8 @@
   /// The way a view changes over time to create a smooth visual transition from one state to
   /// another.
   public struct AppKitAnimation: Hashable, Sendable {
-    fileprivate let framework: Framework
+    @_spi(Internals)
+    public let framework: Framework
 
     @MainActor
     func perform<Result>(
@@ -68,15 +69,16 @@
       }
     }
 
-    fileprivate enum Framework: Hashable, Sendable {
+    @_spi(Internals)
+    public enum Framework: Hashable, Sendable {
       case appKit(AppKit)
       case swiftUI(Animation)
 
-      fileprivate struct AppKit: Hashable, @unchecked Sendable {
-        fileprivate var duration: TimeInterval
-        fileprivate var timingFunction: CAMediaTimingFunction?
+      public struct AppKit: Hashable, @unchecked Sendable {
+        public var duration: TimeInterval
+        public var timingFunction: CAMediaTimingFunction?
 
-        func hash(into hasher: inout Hasher) {
+        public func hash(into hasher: inout Hasher) {
           hasher.combine(duration)
         }
       }

--- a/Sources/SwiftNavigation/UITransaction.swift
+++ b/Sources/SwiftNavigation/UITransaction.swift
@@ -39,7 +39,9 @@ public func withUITransaction<R, V>(
 /// The root transaction for a state change comes from the binding that changed, plus any global
 /// values set by calling ``withUITransaction(_:_:)``.
 public struct UITransaction: Sendable {
-  @TaskLocal package static var current = Self()
+  /// Current TaskLocal transaction
+  @_spi(Internals)
+  @TaskLocal public static var current = Self()
 
   var storage: OrderedDictionary<Key, any Sendable> = [:]
 

--- a/Sources/UIKitNavigation/UIKitAnimation.swift
+++ b/Sources/UIKitNavigation/UIKitAnimation.swift
@@ -30,7 +30,8 @@
   /// The way a view changes over time to create a smooth visual transition from one state to
   /// another.
   public struct UIKitAnimation: Hashable, Sendable {
-    fileprivate let framework: Framework
+    @_spi(Internals)
+    public let framework: Framework
 
     @MainActor
     func perform<Result>(
@@ -115,19 +116,20 @@
       }
     }
 
-    fileprivate enum Framework: Hashable, Sendable {
+    @_spi(Internals)
+    public enum Framework: Hashable, Sendable {
       case uiKit(UIKit)
       case swiftUI(Animation)
 
-      fileprivate struct UIKit: Hashable, Sendable {
-        fileprivate var delay: TimeInterval
-        fileprivate var duration: TimeInterval
-        fileprivate var options: UIView.AnimationOptions
-        fileprivate var repeatModifier: RepeatModifier?
-        fileprivate var speed: Double = 1
-        fileprivate var style: Style
+      public struct UIKit: Hashable, Sendable {
+        public var delay: TimeInterval
+        public var duration: TimeInterval
+        public var options: UIView.AnimationOptions
+        public var repeatModifier: RepeatModifier?
+        public var speed: Double = 1
+        public var style: Style
 
-        func hash(into hasher: inout Hasher) {
+        public func hash(into hasher: inout Hasher) {
           hasher.combine(delay)
           hasher.combine(duration)
           hasher.combine(options.rawValue)
@@ -136,12 +138,12 @@
           hasher.combine(style)
         }
 
-        fileprivate struct RepeatModifier: Hashable, Sendable {
-          var autoreverses = true
-          var count: CGFloat = 1
+        public struct RepeatModifier: Hashable, Sendable {
+          public var autoreverses = true
+          public var count: CGFloat = 1
         }
 
-        fileprivate enum Style: Hashable, Sendable {
+        public enum Style: Hashable, Sendable {
           case iOS4
           case iOS7(dampingRatio: CGFloat, velocity: CGFloat)
           case iOS17(bounce: CGFloat = 0, initialSpringVelocity: CGFloat = 0)


### PR DESCRIPTION
- `UITransaction.current`
- `UIKitAnimation.Framework`
- `AppKitAnimation.Framework`

Even though swift-navigation animates stuff by default, some animations should be handled manually (e.g., CADisplayLink-based animations).

- Accessing Transaction.current allows for implicit checks of animations in the current context.
- Accessing CocoaAnimation.framework enables the extraction of parameters for Cocoa animations without reflection (tho SwiftUI will still require reflection, but at least the Cocoa part will be cleaner 🌚)

The general audience probably doensn't need these APIs so I believe @_spi is a good way to expose them 💁‍♂️