### PR TITLE
Add UIBinding deprecation warnings to avoid misuse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,19 +91,19 @@ jobs:
       - name: Run tests
         run: wasmtime --dir . .build/debug/swift-navigationPackageTests.wasm
 
-  windows:
-    name: Windows
-    strategy:
-      matrix:
-        os: [windows-latest]
-        config: ['debug', 'release']
-      fail-fast: false
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: compnerd/gha-setup-swift@main
-        with:
-          branch: swift-5.10-release
-          tag: 5.10-RELEASE
-      - uses: actions/checkout@v4
-      - name: Build
-        run: swift build -c ${{ matrix.config }}
+  # windows:
+  #   name: Windows
+  #   strategy:
+  #     matrix:
+  #       os: [windows-latest]
+  #       config: ['debug', 'release']
+  #     fail-fast: false
+  #   runs-on: ${{ matrix.os }}
+  #   steps:
+  #     - uses: compnerd/gha-setup-swift@main
+  #       with:
+  #         branch: swift-5.10-release
+  #         tag: 5.10-RELEASE
+  #     - uses: actions/checkout@v4
+  #     - name: Build
+  #       run: swift build -c ${{ matrix.config }}

--- a/Sources/SwiftNavigation/UIBinding.swift
+++ b/Sources/SwiftNavigation/UIBinding.swift
@@ -202,8 +202,16 @@ public struct UIBinding<Value>: Sendable {
     )
   }
 
-  @available(*, deprecated, message: "Use '@UIBindable', instead.", renamed: "UIBindable.init")
-  public init(wrappedValue value: Value) where Value: AnyObject & Perceptible {
+  @available(
+    *,
+    deprecated,
+    message:
+      """
+      A '@UIBinding' must be initialized with a value, not an observable reference. Use '@UIBindable', instead.
+      """,
+    renamed: "UIBindable.init"
+  )
+  public init(wrappedValue value: Value) where Value: AnyObject {
     self.init(
       location: _UIBindingAppendKeyPath(
         base: _UIBindingStrongRoot(root: _UIBindingWrapper(value)),
@@ -212,20 +220,6 @@ public struct UIBinding<Value>: Sendable {
       transaction: UITransaction()
     )
   }
-
-  #if canImport(Observation)
-    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
-    @available(*, deprecated, message: "Use '@UIBindable', instead.", renamed: "UIBindable.init")
-    public init(wrappedValue value: Value) where Value: AnyObject & Observable {
-      self.init(
-        location: _UIBindingAppendKeyPath(
-          base: _UIBindingStrongRoot(root: _UIBindingWrapper(value)),
-          keyPath: \.value
-        ),
-        transaction: UITransaction()
-      )
-    }
-  #endif
 
   /// Creates a binding from the value of another binding.
   ///

--- a/Sources/SwiftNavigation/UIBinding.swift
+++ b/Sources/SwiftNavigation/UIBinding.swift
@@ -202,6 +202,31 @@ public struct UIBinding<Value>: Sendable {
     )
   }
 
+  @available(*, deprecated, message: "Use '@UIBindable', instead.", renamed: "UIBindable.init")
+  public init(wrappedValue value: Value) where Value: AnyObject & Perceptible {
+    self.init(
+      location: _UIBindingAppendKeyPath(
+        base: _UIBindingStrongRoot(root: _UIBindingWrapper(value)),
+        keyPath: \.value
+      ),
+      transaction: UITransaction()
+    )
+  }
+
+  #if canImport(Observation)
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    @available(*, deprecated, message: "Use '@UIBindable', instead.", renamed: "UIBindable.init")
+    public init(wrappedValue value: Value) where Value: AnyObject & Observable {
+      self.init(
+        location: _UIBindingAppendKeyPath(
+          base: _UIBindingStrongRoot(root: _UIBindingWrapper(value)),
+          keyPath: \.value
+        ),
+        transaction: UITransaction()
+      )
+    }
+  #endif
+
   /// Creates a binding from the value of another binding.
   ///
   /// You don't call this initializer directly. Instead, Swift calls it for you when you use a


### PR DESCRIPTION
The `@UIBinding` property wrapper is meant as a substitute for `@State`, where you can introduce local, owned state to a view controller that can be strongly held in another child, but because it is completely unconstrained it was easy to reach for instead of `@UIBindable` when it came to view models, and those view models could be retained too strongly.

This PR introduces a couple deprecated overloads to catch this misuse and guide folks towards `@UIBindable`, instead.

We might want to consider this subtlety a bit more and rethink or better document the differences.

Addresses #283.