### PR TITLE
UIKit: Prevent redundant dismissal of already-dismissing view controller

### DIFF
--- a/Sources/UIKitNavigation/Navigation/Presentation.swift
+++ b/Sources/UIKitNavigation/Navigation/Presentation.swift
@@ -121,7 +121,10 @@
         content($item)
       } present: { [weak self] child, transaction in
         guard let self else { return }
-        if presentedViewController != nil {
+        if presentedViewController != nil,
+           presentedViewController?.isBeingDismissed == false,
+           presentedViewController?.isMovingFromParent == false
+        {
           self.dismiss(animated: !transaction.uiKit.disablesAnimations) {
             onDismiss?()
             self.present(child, animated: !transaction.uiKit.disablesAnimations)


### PR DESCRIPTION
This fixes an issue where presenting a view controller just after dismissing one results in dismissing the presenting view controller.

When a view controller was already in the process of being dismissed (`isBeingDismissed` = true) or moving from its parent (`isMovingFromParent` = true), the presentation logic would still attempt to call `dismiss()` on it again, causing unintended dismissals in the presentation hierarchy.

---------

#### Without the fix:
Pressing the save button dismisses the currently presented view controller and immediately presents the timer view controller. However, due to a bug, the presenting view controller is also dismissed.

https://github.com/user-attachments/assets/626f492f-4cfe-4ed1-af24-461a7084e0bb

---------

#### With the fix:
Pressing the save button correctly dismisses the currently presented view controller and then presents the timer view controller without affecting the presenting view controller.

https://github.com/user-attachments/assets/38d3965d-2938-4c04-a433-25d4471db819

