### PR TITLE
`observe` should take `@isolated(any)` functions

### DIFF
--- a/Sources/SwiftNavigation/NSObject+Observe.swift
+++ b/Sources/SwiftNavigation/NSObject+Observe.swift
@@ -121,7 +121,7 @@
     public func observe(
       _ apply: @escaping @MainActor @Sendable (_ transaction: UITransaction) -> Void
     ) -> ObserveToken {
-      let token = SwiftNavigation.observe { transaction in
+      let token = SwiftNavigation._observe { transaction in
         MainActor._assumeIsolated {
           apply(transaction)
         }


### PR DESCRIPTION
The current signatures were the result of fighting language changes in real time, and while it mostly worked in a non-default main actor world, I think this is more correct.