### PR TITLE
Fix broken alert dimissal

### DIFF
--- a/Sources/UIKitNavigation/Navigation/Presentation.swift
+++ b/Sources/UIKitNavigation/Navigation/Presentation.swift
@@ -338,6 +338,7 @@
       ) -> Void
     ) -> ObserveToken {
       let key = UIBindingIdentifier(item)
+      var inFlightController: UIViewController?
       return observe { [weak self] transaction in
         guard let self else { return }
         if let unwrappedItem = UIBinding(item) {
@@ -349,10 +350,14 @@
             }
           }
           let childController = content(unwrappedItem)
-          let onDismiss = { [presentationID = id(unwrappedItem.wrappedValue)] in
+          let onDismiss = { [
+            weak self,
+            presentationID = id(unwrappedItem.wrappedValue)
+          ] in
             if let wrappedValue = item.wrappedValue,
               presentationID == id(wrappedValue)
             {
+              inFlightController = self?.presentedByID[key]?.controller
               item.wrappedValue = nil
             }
           }
@@ -378,6 +383,7 @@
             dismiss(controller, transaction)
           }
           self.presentedByID[key] = nil
+          inFlightController = nil
         }
       }
     }

--- a/Sources/UIKitNavigationShim/shim.m
+++ b/Sources/UIKitNavigationShim/shim.m
@@ -51,10 +51,26 @@
       [self UIKitNavigation_viewDidDisappear:animated];
 
       if ((self.isBeingDismissed || self.isMovingFromParentViewController) && self._UIKitNavigation_onDismiss != NULL) {
-        self._UIKitNavigation_onDismiss();
-        dispatch_async(dispatch_get_main_queue(), ^{
+        if ([self isKindOfClass:UIAlertController.class]) {
+          // NB: Currently, onDismiss is called before the UIAlertAction
+          //     is processed, which generally isn't an issue, but if you
+          //     care about the order of operations, this can be a bit thorny.
+          //     In the case of highly generalized navigation patterns in TCA,
+          //     the order is what we use to emit warnings when invalid actions
+          //     are received (like a dismiss action is received for an
+          //     already-dismissed feature), so let's address the problem with
+          //     a quick tick.
+          //
+          //     We could do this thread hop unconditionally if it makes sense
+          //     to, but let's localize to UIAlertController for now.
+          dispatch_async(dispatch_get_main_queue(), ^{
+            self._UIKitNavigation_onDismiss();
+            self._UIKitNavigation_onDismiss = nil;
+          });
+        } else {
+          self._UIKitNavigation_onDismiss();
           self._UIKitNavigation_onDismiss = nil;
-        });
+        }
       }
     }
 


### PR DESCRIPTION
It appears that nil-ing out the shim's dismiss property in the next run loop was not the approach to take in https://github.com/pointfreeco/swift-navigation/pull/303 since it broke how UIAlertController's are programmatically dismissed (which was made very obvious in my TCA app).

I suspect that didn't see this issue before when I was using the fix because I was applying the change on top of an earlier version of `swift-navigation`. Don't know for sure, but  fortunately I had a Plan B in that PR that fixes both the issue that existed in https://github.com/pointfreeco/swift-navigation/pull/303, _and_ also the broken alert dismissal issues I'm currently seeing.