### PR TITLE
Dismiss should be called on child being passed in onDismiss closure

### DIFF
--- a/Sources/UIKitNavigation/Navigation/Presentation.swift
+++ b/Sources/UIKitNavigation/Navigation/Presentation.swift
@@ -129,8 +129,8 @@
         } else {
           self.present(child, animated: !transaction.uiKit.disablesAnimations)
         }
-      } dismiss: { [weak self] _, transaction in
-        self?.dismiss(animated: !transaction.uiKit.disablesAnimations) {
+      } dismiss: { [weak self] child, transaction in
+        child.dismiss(animated: !transaction.uiKit.disablesAnimations) {
           onDismiss?()
         }
       }


### PR DESCRIPTION
Addresses https://github.com/pointfreeco/swift-navigation/issues/309.

The issue is that the dismiss closure being passed the controller to be dismissed, but the actual area where the dismissal occurs is using `self` instead of the respective controller. At least, that's the theory...let's see if tests pass. I was able to at least fix the issue that was in #309 with it.