### PR TITLE
Fix `UINavigationControllerDelegate`'s forwarding

### DIFF
--- a/Sources/UIKitNavigation/Navigation/NavigationStackController.swift
+++ b/Sources/UIKitNavigation/Navigation/NavigationStackController.swift
@@ -196,8 +196,9 @@
       weak var base: (any UINavigationControllerDelegate)?
 
       override func responds(to aSelector: Selector!) -> Bool {
-        (MainActor._assumeIsolated { base?.responds(to: aSelector) } ?? false)
-          || aSelector == #selector(navigationController(_:didShow:animated:))
+        aSelector == #selector(navigationController(_:didShow:animated:))
+          || MainActor._assumeIsolated { base?.responds(to: aSelector) }
+            ?? false
       }
 
       func navigationController(

--- a/Sources/UIKitNavigation/Navigation/NavigationStackController.swift
+++ b/Sources/UIKitNavigation/Navigation/NavigationStackController.swift
@@ -196,24 +196,8 @@
       weak var base: (any UINavigationControllerDelegate)?
 
       override func responds(to aSelector: Selector!) -> Bool {
-        #if !os(tvOS) && !os(watchOS)
-          aSelector == #selector(navigationController(_:willShow:animated:))
-            || aSelector == #selector(navigationController(_:didShow:animated:))
-            || aSelector == #selector(navigationControllerSupportedInterfaceOrientations(_:))
-            || aSelector == #selector(
-              navigationControllerPreferredInterfaceOrientationForPresentation(_:))
-            || aSelector == #selector(navigationController(_:interactionControllerFor:))
-            || aSelector == #selector(navigationController(_:animationControllerFor:from:to:))
-            || MainActor._assumeIsolated { base?.responds(to: aSelector) }
-              ?? false
-        #else
-          aSelector == #selector(navigationController(_:willShow:animated:))
-            || aSelector == #selector(navigationController(_:didShow:animated:))
-            || aSelector == #selector(navigationController(_:interactionControllerFor:))
-            || aSelector == #selector(navigationController(_:animationControllerFor:from:to:))
-            || MainActor._assumeIsolated { base?.responds(to: aSelector) }
-              ?? false
-        #endif
+        (MainActor._assumeIsolated { base?.responds(to: aSelector) } ?? false)
+          || aSelector == #selector(navigationController(_:didShow:animated:))
       }
 
       func navigationController(


### PR DESCRIPTION
#307 changed the behavior of the `UINavigationControllderDelegate`'s forwarding: all the methods of this protocol are optional but the only cases where we'd want to return `true` to `respondsToSelector` are:
- When the base `delegate` is not nil and responds to the selector [^1]
- When the method is `navigationController(_:didShow:animated:)` which is the only one where we perform some effective business logic.

Otherwise, the current implementation forces `base` to properly implement all delegate methods (which is not a requirement when using a standard `UINavigationController`). For example, this breaks interactive pop if `base` is only used to track `willShow`, as UIKit will otherwise assume that the delegate implements `animationControllerFor:from:to:` and returns `nil`, which iOS infers as having no interactive dismissal ([the documentation is inexact](https://developer.apple.com/documentation/uikit/uinavigationcontrollerdelegate/navigationcontroller(_:animationcontrollerfor:from:to:)) and `nil` means no `animationController`, not "use defaults", at least from Swift)

As a bonus, it allows to simplify the implementation.

[^1]: Note that is this not 100% correct, as we're not forwarding any method, but in that occurrence, we only expect `UINavigationControllerDelegate` calls to be made. I'm not sure we want to start tweaking the `perform` methods.