### PR TITLE
Fix for crash when dismissing UIViewControllers when building with Xcode 26

### DIFF
--- a/Sources/UIKitNavigationShim/shim.m
+++ b/Sources/UIKitNavigationShim/shim.m
@@ -69,7 +69,9 @@
           });
         } else {
           self._UIKitNavigation_onDismiss();
-          self._UIKitNavigation_onDismiss = nil;
+          dispatch_async(dispatch_get_main_queue(), ^{
+            self._UIKitNavigation_onDismiss = nil;
+          });
         }
       }
     }


### PR DESCRIPTION
Addresses https://github.com/pointfreeco/swift-navigation/issues/313

This change re-instates the original thread-hop before nilling out dismiss closure that was present in 2.5.0, for the non-UIAlertController case.

See https://github.com/pointfreeco/swift-navigation/compare/2.5.0...2.5.1

This fixes the issue, but I don't really have any clarity on why.  Some quirk with the Xcode 26 toolset.