### PR TITLE
Add support for `LocalizedStringResource`

### DIFF
--- a/Sources/SwiftNavigation/TextState.swift
+++ b/Sources/SwiftNavigation/TextState.swift
@@ -189,6 +189,13 @@ extension TextState {
     self.init(verbatim: String(content))
   }
 
+  @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+  public init(
+    _ resource: LocalizedStringResource
+  ) {
+    self.storage = .verbatim(String(localized: resource))
+  }
+
   #if canImport(SwiftUI)
     public init(
       _ key: LocalizedStringKey,
@@ -386,6 +393,16 @@ extension TextState {
     public func accessibilityLabel<S: StringProtocol>(_ string: S) -> Self {
       var `self` = self
       `self`.modifiers.append(.accessibilityLabel(.init(string)))
+      return `self`
+    }
+
+    @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+    public func accessibilityLabel(
+      _ resource: LocalizedStringResource
+    ) -> Self {
+      var `self` = self
+      `self`.modifiers.append(
+        .accessibilityLabel(.init(verbatim: String(localized: resource))))
       return `self`
     }
 

--- a/Tests/SwiftNavigationTests/TextStateTests.swift
+++ b/Tests/SwiftNavigationTests/TextStateTests.swift
@@ -72,5 +72,18 @@ final class TextStateTests: XCTestCase {
         """#
       )
     }
+
+  @available(macOS 13, iOS 16, tvOS 16, watchOS 9, *)
+  func testTextStateLocalizedStringResource() {
+    var dump = ""
+    let resource = LocalizedStringResource("hello.world", defaultValue: "Hello, world!")
+    customDump(TextState(resource), to: &dump)
+    XCTAssertEqual(
+      dump,
+      """
+      "Hello, world!"
+      """
+    )
+  }
   #endif
 }


### PR DESCRIPTION
A small PR to add an initializers for `LocalizedStringResource` for convenience. 

Apple is pushing developers away from `LocalizedStringKey` and instead recommending they use [`LocalizedStringResource`](https://developer.apple.com/documentation/Foundation/LocalizedStringResource) going forward.

> LocalizedStringResource is the recommended type for representing and passing around localizable strings. It not only supports initialization using a string literal, but can also be provided with a comment, table name, or even a default value that's different from the string key.

There are a variety of benefits of resources over keys mentioned in Apple's docs.

While it is easy enough to call `String(localized:)` ourselves when using `TextState`, adding this initializer feels like a small amount of effort for a sizable convenience for consumers.