### PR TITLE
Fix `UITabBarController` binding updates

### DIFF
--- a/Sources/UIKitNavigation/Bindings/UITabBarController.swift
+++ b/Sources/UIKitNavigation/Bindings/UITabBarController.swift
@@ -36,9 +36,20 @@
         }
         self.selectedTab = tab
       }
-      let observation = observe(\.selectedTab) { controller, _ in
+      let observation = tabBar.observe(\.selectedItem) { [weak self] tabBar, _ in
+        guard let self else { return }
         MainActor.assumeIsolated {
-          selectedTab.wrappedValue = controller.selectedTab?.identifier
+          let identifier: String?
+          if let item = tabBar.selectedItem,
+             let items = tabBar.items,
+             let index = items.firstIndex(of: item),
+             tabs.indices.contains(index) {
+            identifier = tabs[index].identifier
+          } else {
+            identifier = self.selectedTab?.identifier
+          }
+          guard selectedTab.wrappedValue != identifier else { return }
+          selectedTab.wrappedValue = identifier
         }
       }
       let observeToken = ObserveToken {

--- a/Tests/UIKitNavigationTests/UITabBarControllerBindingTests.swift
+++ b/Tests/UIKitNavigationTests/UITabBarControllerBindingTests.swift
@@ -1,0 +1,45 @@
+#if canImport(UIKit) && !os(tvOS) && !os(watchOS)
+  import UIKit
+  import UIKitNavigation
+  import XCTest
+
+  @available(iOS 18, visionOS 2, *)
+  final class UITabBarControllerBindingTests: XCTestCase {
+    @MainActor
+    func testSelectedTabBindingUpdatesBothWays() async throws {
+      @UIBinding var selectedIdentifier: String? = "first"
+      let controller = UITabBarController()
+      let firstTab = UITab(
+        title: "First",
+        image: nil,
+        identifier: "first"
+      ) { _ in
+        UIViewController()
+      }
+      let secondTab = UITab(
+        title: "Second",
+        image: nil,
+        identifier: "second"
+      ) { _ in
+        UIViewController()
+      }
+
+      controller.setTabs([firstTab, secondTab], animated: false)
+
+      let token = controller.bind(selectedTab: $selectedIdentifier)
+      defer { token.cancel() }
+
+      await Task.yield()
+      XCTAssertEqual(selectedIdentifier, "first")
+      XCTAssertEqual(controller.selectedTab?.identifier, "first")
+
+      selectedIdentifier = "second"
+      await Task.yield()
+      XCTAssertEqual(controller.selectedTab?.identifier, "second")
+
+      controller.selectedIndex = 0
+      await Task.yield()
+      XCTAssertEqual(selectedIdentifier, "first")
+    }
+  }
+#endif


### PR DESCRIPTION
Fixes a tab selection binding issue in `UITabBarController.bind(selectedTab:)`.
I think the "new" `selectedTab` property is not KVO compliant, so it cannot be observed.