### PR TITLE
UIKit: Fix switch presented child double dismiss

### DIFF
--- a/Examples/CaseStudiesTests/PresentationTests.swift
+++ b/Examples/CaseStudiesTests/PresentationTests.swift
@@ -138,6 +138,32 @@ final class PresentationTests: XCTestCase {
   }
 
   @MainActor
+  func testPresents_ChangePresentedScreenInPresented() async throws {
+    let vc = BasicViewController()
+    try await setUp(controller: vc)
+
+    await assertEventuallyNil(vc.presentedViewController)
+
+    withUITransaction(\.uiKit.disablesAnimations, true) {
+      vc.model.presentedChild = Model()
+    }
+    await assertEventuallyNotNil(vc.presentedViewController)
+
+    withUITransaction(\.uiKit.disablesAnimations, true) {
+      vc.model.presentedChild?.presentedChild = Model()
+    }
+    await assertEventuallyNotNil(vc.presentedViewController)
+
+    try await Task.sleep(for: .seconds(0.5))
+    withUITransaction(\.uiKit.disablesAnimations, true) {
+      vc.model.presentedChild?.presentedChild = Model()
+    }
+
+    try await Task.sleep(for: .seconds(0.5))
+    await assertEventuallyNotNil(vc.presentedViewController)
+  }
+
+  @MainActor
   func testPushViewController_IsPushed() async throws {
     let vc = BasicViewController()
     let nav = UINavigationController(rootViewController: vc)

--- a/Sources/UIKitNavigation/Navigation/Presentation.swift
+++ b/Sources/UIKitNavigation/Navigation/Presentation.swift
@@ -121,12 +121,22 @@
         content($item)
       } present: { [weak self] child, transaction in
         guard let self else { return }
-        if presentedViewController != nil {
-          self.dismiss(
-            animated: !transaction.uiKit.disablesAnimations
-          ) {
-            onDismiss?()
-            self.present(child, animated: !transaction.uiKit.disablesAnimations)
+        if let presentedViewController {
+          if presentedViewController.isBeingDismissed {
+            let oldViewControllerOnDismiss = presentedViewController._UIKitNavigation_onDismiss
+            // If already being dismissed wait for it to be dismissed
+            // and present the new after that.
+            presentedViewController._UIKitNavigation_onDismiss = {
+              oldViewControllerOnDismiss?()
+              self.present(child, animated: !transaction.uiKit.disablesAnimations)
+            }
+          } else {
+            self.dismiss(
+              animated: !transaction.uiKit.disablesAnimations
+            ) {
+              onDismiss?()
+              self.present(child, animated: !transaction.uiKit.disablesAnimations)
+            }
           }
         } else {
           self.present(child, animated: !transaction.uiKit.disablesAnimations)

--- a/Sources/UIKitNavigation/Navigation/Presentation.swift
+++ b/Sources/UIKitNavigation/Navigation/Presentation.swift
@@ -124,8 +124,6 @@
         if let presentedViewController {
           if presentedViewController.isBeingDismissed {
             let oldViewControllerOnDismiss = presentedViewController._UIKitNavigation_onDismiss
-            // If already being dismissed wait for it to be dismissed
-            // and present the new after that.
             presentedViewController._UIKitNavigation_onDismiss = {
               oldViewControllerOnDismiss?()
               self.present(child, animated: !transaction.uiKit.disablesAnimations)


### PR DESCRIPTION
Sometimes when changing the presented view controller from one to another, the parent also gets dismissed.

The fix is to check if the `presentedViewController` is already being dismissed. If it is, wait for it to finish dismissing before presenting the new one. I'm piggybacking on `_UIKitNavigation_onDismiss` to get a callback when the view controller is dismissed. Not sure if that is the best way to do it. We've used this in our project and it seems to work.