### PR TITLE
Enable root view controller replacement in `NavigationStackController`

### DIFF
--- a/Sources/UIKitNavigation/Navigation/NavigationStackController.swift
+++ b/Sources/UIKitNavigation/Navigation/NavigationStackController.swift
@@ -20,7 +20,16 @@
       }
     }
     private let pathDelegate = PathDelegate()
-    private var root: UIViewController?
+
+    public var rootViewController: UIViewController {
+      didSet {
+        if viewControllers.isEmpty {
+          viewControllers = [rootViewController]
+        } else {
+          viewControllers[0] = rootViewController
+        }
+      }
+    }
 
     public override weak var delegate: (any UINavigationControllerDelegate)? {
       get { pathDelegate.base }
@@ -33,11 +42,11 @@
       path: UIBinding<Data>,
       root: () -> UIViewController
     ) where Data.Element: Hashable {
+      let root = root()
+      self.rootViewController = root
       super.init(navigationBarClass: navigationBarClass, toolbarClass: toolbarClass)
       self._path = path.path
-      let root = root()
-      self.root = root
-      self.viewControllers = [root]
+      self.viewControllers = [rootViewController]
     }
 
     public required init(
@@ -46,10 +55,10 @@
       path: UIBinding<UINavigationPath>,
       root: () -> UIViewController
     ) {
+      let root = root()
+      self.rootViewController = root
       super.init(navigationBarClass: navigationBarClass, toolbarClass: toolbarClass)
       self._path = path.elements
-      let root = root()
-      self.root = root
       self.viewControllers = [root]
     }
 
@@ -76,8 +85,8 @@
         let difference = newPath.difference(from: viewControllers.compactMap(\.navigationID))
 
         guard !difference.isEmpty else {
-          if viewControllers.isEmpty, let root {
-            setViewControllers([root], animated: true)
+          if viewControllers.isEmpty {
+            setViewControllers([rootViewController], animated: true)
           }
           return
         }
@@ -107,7 +116,7 @@
           var newPath = newPath
           let oldViewControllers =
             viewControllers.isEmpty
-            ? root.map { [$0] } ?? []
+            ? [rootViewController]
             : viewControllers
           var newViewControllers: [UIViewController] = []
           newViewControllers.reserveCapacity(max(viewControllers.count, newPath.count))


### PR DESCRIPTION
This change addresses an issue that arises when using `NavigationStackController` in combination with `UISplitViewController`.

In my project, I configure the split view's columns at runtime by passing `NavigationStackController` instances to [UISplitViewController.setViewController(_:for:)](https://developer.apple.com/documentation/uikit/uisplitviewcontroller/setviewcontroller(_:for:))￼. While this works as expected for primary/secondary/supplementary/inspector columns, it does not behave correctly for the compact column.

On iOS 17 and earlier, the compact column is intended to be configured only once; subsequent attempts to replace it are ignored. As a result, dynamically updating the compact column by swapping out the entire navigation stack is not a viable approach.

If `NavigationStackController` allowed updating its root view controller instead of requiring replacement of the entire stack, this limitation could be avoided.

I understand that `NavigationStackController` is modeled after SwiftUI’s `NavigationStack`. However, `NavigationStack` provides greater flexibility by accepting a `ViewBuilder` to construct its root content dynamically.