### PR TITLE
[UIAlertController] Add preferred button support

### DIFF
--- a/Sources/SwiftNavigation/ButtonState.swift
+++ b/Sources/SwiftNavigation/ButtonState.swift
@@ -10,6 +10,9 @@ public import Foundation
 public struct ButtonState<Action>: Identifiable {
   public let id: UUID
   public let action: ButtonStateAction<Action>
+  /// A Boolean value that indicates whether supporting UI components should make this button the
+  /// preferred action.
+  public let isPreferred: Bool
   public let label: TextState
   public let role: ButtonStateRole?
 
@@ -17,10 +20,12 @@ public struct ButtonState<Action>: Identifiable {
     id: UUID,
     action: ButtonStateAction<Action>,
     label: TextState,
-    role: ButtonStateRole?
+    role: ButtonStateRole?,
+    isPreferred: Bool = false
   ) {
     self.id = id
     self.action = action
+    self.isPreferred = isPreferred
     self.label = label
     self.role = role
   }
@@ -118,7 +123,21 @@ public struct ButtonState<Action>: Identifiable {
       id: self.id,
       action: self.action.map(transform),
       label: self.label,
-      role: self.role
+      role: self.role,
+      isPreferred: self.isPreferred
+    )
+  }
+
+  /// Returns a copy of the button state that is or is not preferred.
+  ///
+  /// Supporting UI components can use a preferred button as their default action.
+  public func preferred(_ isPreferred: Bool = true) -> Self {
+    ButtonState(
+      id: self.id,
+      action: self.action,
+      label: self.label,
+      role: self.role,
+      isPreferred: isPreferred
     )
   }
 }
@@ -190,6 +209,7 @@ extension ButtonStateRole: Equatable {}
 extension ButtonState: Equatable where Action: Equatable {
   public static func == (lhs: Self, rhs: Self) -> Bool {
     lhs.action == rhs.action
+      && lhs.isPreferred == rhs.isPreferred
       && lhs.label == rhs.label
       && lhs.role == rhs.role
   }
@@ -212,6 +232,7 @@ extension ButtonStateRole: Hashable {}
 extension ButtonState: Hashable where Action: Hashable {
   public func hash(into hasher: inout Hasher) {
     hasher.combine(self.action)
+    hasher.combine(self.isPreferred)
     hasher.combine(self.label)
     hasher.combine(self.role)
   }

--- a/Sources/SwiftNavigation/Documentation.docc/Extensions/ButtonState.md
+++ b/Sources/SwiftNavigation/Documentation.docc/Extensions/ButtonState.md
@@ -6,6 +6,7 @@
 
 - ``init(role:action:label:)-65t48``
 - ``init(role:action:label:)-8tmop``
+- ``preferred(_:)``
 - ``ButtonStateRole``
 - ``ButtonStateAction``
 
@@ -17,6 +18,7 @@
 
 - ``id``
 - ``role-swift.property``
+- ``isPreferred``
 - ``action``
 - ``label``
 

--- a/Sources/SwiftNavigation/Traits/CustomDump.swift
+++ b/Sources/SwiftNavigation/Traits/CustomDump.swift
@@ -30,6 +30,9 @@
       if let role = self.role {
         children.append(("role", role))
       }
+      if self.isPreferred {
+        children.append(("isPreferred", self.isPreferred))
+      }
       children.append(("action", self.action))
       children.append(("label", self.label))
       return Mirror(

--- a/Sources/UIKitNavigation/Navigation/UIAlertController.swift
+++ b/Sources/UIKitNavigation/Navigation/UIAlertController.swift
@@ -29,9 +29,7 @@
         message: state.message.map { String(state: $0) },
         preferredStyle: .alert
       )
-      for button in state.buttons {
-        addAction(UIAlertAction(button, action: handler))
-      }
+      self.addActions(state.buttons, stateName: "AlertState", handler: handler)
       if state.buttons.isEmpty {
         addAction(UIAlertAction(title: "OK", style: .cancel))
       }
@@ -73,11 +71,30 @@
         message: state.message.map { String(state: $0) },
         preferredStyle: .actionSheet
       )
-      for button in state.buttons {
-        addAction(UIAlertAction(button, action: handler))
-      }
+      self.addActions(state.buttons, stateName: "ConfirmationDialogState", handler: handler)
       if state.buttons.isEmpty {
         addAction(UIAlertAction(title: "OK", style: .cancel))
+      }
+    }
+
+    private func addActions<Action>(
+      _ buttons: [ButtonState<Action>],
+      stateName: String,
+      handler: @escaping (_ action: Action?) -> Void
+    ) {
+      let actions = buttons.map { UIAlertAction($0, action: handler) }
+      for action in actions {
+        self.addAction(action)
+      }
+      let preferred = zip(buttons, actions).filter(\.0.isPreferred).map(\.1)
+      self.preferredAction = preferred.first
+      if preferred.count > 1 {
+        reportIssue(
+          """
+          'UIAlertController' received '\(stateName)' with multiple preferred buttons. Will use \
+          the first preferred button.
+          """
+        )
       }
     }
   }

--- a/Tests/SwiftNavigationTests/ButtonStateTests.swift
+++ b/Tests/SwiftNavigationTests/ButtonStateTests.swift
@@ -7,6 +7,47 @@
 
   struct ButtonStateTests {
     @Test
+    func preferred() {
+      let button = ButtonState(action: true) {
+        TextState("OK")
+      }
+
+      #expect(!button.isPreferred)
+      #expect(button.preferred().isPreferred)
+      #expect(!button.preferred(false).isPreferred)
+      #expect(button != button.preferred())
+
+      var dump = ""
+      customDump(button.preferred(), to: &dump)
+      expectNoDifference(
+        dump,
+        """
+        ButtonState(
+          isPreferred: true,
+          action: .send(
+            true
+          ),
+          label: "OK"
+        )
+        """
+      )
+    }
+
+    @Test
+    func mapPreservesPreferred() {
+      let button = ButtonState(action: 42) {
+        TextState("OK")
+      }
+      .preferred()
+
+      let mappedButton = button.map { action in
+        action.map(String.init)
+      }
+
+      #expect(mappedButton.isPreferred)
+    }
+
+    @Test
     func testAsyncAnimationWarning() async {
       let button = ButtonState(action: .send((), animation: .easeInOut)) {
         TextState("Animate!")

--- a/Tests/UIKitNavigationTests/UIAlertControllerTests.swift
+++ b/Tests/UIKitNavigationTests/UIAlertControllerTests.swift
@@ -1,0 +1,78 @@
+#if canImport(UIKit) && !os(watchOS)
+  import UIKitNavigation
+  import XCTest
+
+  @available(iOS 13, tvOS 13, *)
+  final class UIAlertControllerTests: XCTestCase {
+    @MainActor
+    func testAlertPreferredAction() {
+      let controller = UIAlertController(
+        state: AlertState {
+          TextState("Title")
+        } actions: {
+          ButtonState(action: 1) {
+            TextState("First")
+          }
+          ButtonState(action: 2) {
+            TextState("Second")
+          }
+          .preferred()
+        }
+      )
+
+      XCTAssertTrue(controller.preferredAction === controller.actions[1])
+    }
+
+    @MainActor
+    func testConfirmationDialogPreferredAction() {
+      let controller = UIAlertController(
+        state: ConfirmationDialogState {
+          TextState("Title")
+        } actions: {
+          ButtonState(action: 1) {
+            TextState("First")
+          }
+          ButtonState(action: 2) {
+            TextState("Second")
+          }
+          .preferred()
+        }
+      )
+
+      XCTAssertTrue(controller.preferredAction === controller.actions[1])
+    }
+
+    @MainActor
+    func testMultiplePreferredActionsReportIssueAndUseFirstPreferredAction() {
+      var controller: UIAlertController?
+
+      XCTExpectFailure {
+        controller = UIAlertController(
+          state: ConfirmationDialogState {
+            TextState("Title")
+          } actions: {
+            ButtonState(action: 1) {
+              TextState("First")
+            }
+            .preferred()
+            ButtonState(action: 2) {
+              TextState("Second")
+            }
+            .preferred()
+          }
+        )
+      } issueMatcher: {
+        $0.compactDescription
+          == """
+          failed - 'UIAlertController' received 'ConfirmationDialogState' with multiple preferred buttons. Will use the first preferred button.
+          """
+      }
+
+      guard let controller else {
+        XCTFail("Expected a controller.")
+        return
+      }
+      XCTAssertTrue(controller.preferredAction === controller.actions[0])
+    }
+  }
+#endif


### PR DESCRIPTION
UIKit exposes `preferredAction` as the way to mark the action a person is most likely to take from an alert.   
Per [Apple's documentation](https://developer.apple.com/documentation/UIKit/UIAlertController/preferredAction), UIKit gives that action additional emphasis and lets the Return key trigger it when a physical keyboard is connected.

- Adds `ButtonState.isPreferred` and `.preferred(_:)`.
- Preserves preferredness through `ButtonState.map`, equality, hashing, and custom dump output.
- Updates UIKit `UIAlertController` bridging for both `AlertState` and `ConfirmationDialogState` to set `preferredAction`.
- Reports an issue when multiple buttons are marked preferred, while deterministically using the first one.
- Adds focused value-level and UIKit tests.

## Example

```swift
state.applyChangesToRoutineDialog = ConfirmationDialogState(
  titleVisibility: .visible,
  title: {
    TextState("Update Routine?", bundle: .module)
  },
  actions: {
    ButtonState(action: .onlyReplaceTrainingExercise) {
      TextState("Training Only", bundle: .module)
    }
    .preferred() // 🟢🟢🟢 This is the new API! 🟢🟢🟢

    ButtonState(action: .replaceBoth) {
      TextState("Update Both", bundle: .module)
    }
  },
  message: {
    TextState(
      "Should the linked routine also be updated with these exercise changes?",
      bundle: .module
    )
  }
)
```

<img width="349" src="https://github.com/user-attachments/assets/7fcc1256-1278-4edf-a44d-cccf472ca569" />

