### PR TITLE
`@CaseBindable`

### DIFF
--- a/Examples/CaseStudies/SwiftUI/EnumControls.swift
+++ b/Examples/CaseStudies/SwiftUI/EnumControls.swift
@@ -12,11 +12,11 @@ struct EnumControls: SwiftUICaseStudy, View {
     • A Boolean for whether an item is on back order when it is _not_ in stock, which can drive a \
     toggle.
 
-    This library provides tools to chain deeper into a binding's case by applying the \
-    `@CasePathable` macro.
+    By applying the `@CaseBindable` macro to the enum you can switch over a binding's cases \
+    directly, and each case is handed a binding to its associated value.
     """
 
-  @CasePathable
+  @CaseBindable
   enum Status {
     case inStock(quantity: Int)
     case outOfStock(isOnBackOrder: Bool)
@@ -25,28 +25,24 @@ struct EnumControls: SwiftUICaseStudy, View {
   @State var status: Status = .inStock(quantity: 100)
 
   var body: some View {
-    switch status {
-    case .inStock:
-      $status.inStock.map { $quantity in
-        Section {
-          Stepper("Quantity: \(quantity)", value: $quantity)
-          Button("Out of stock") {
-            status = .outOfStock(isOnBackOrder: false)
-          }
-        } header: {
-          Text("In stock")
+    switch $status.cases {
+    case .inStock(let $quantity):
+      Section {
+        Stepper("Quantity: \($quantity.wrappedValue)", value: $quantity)
+        Button("Out of stock") {
+          status = .outOfStock(isOnBackOrder: false)
         }
+      } header: {
+        Text("In stock")
       }
-    case .outOfStock:
-      $status.outOfStock.map { $isOnBackOrder in
-        Section {
-          Toggle("Is on back order?", isOn: $isOnBackOrder)
-          Button("Back in stock!") {
-            status = .inStock(quantity: 100)
-          }
-        } header: {
-          Text("Out of stock")
+    case .outOfStock(let $isOnBackOrder):
+      Section {
+        Toggle("Is on back order?", isOn: $isOnBackOrder)
+        Button("Back in stock!") {
+          status = .inStock(quantity: 100)
         }
+      } header: {
+        Text("Out of stock")
       }
     }
   }

--- a/Examples/CaseStudies/UIKit/EnumControlsViewController.swift
+++ b/Examples/CaseStudies/UIKit/EnumControlsViewController.swift
@@ -12,11 +12,11 @@ class EnumControlsViewController: UIViewController, UIKitCaseStudy {
     • A Boolean for whether an item is on back order when it is _not_ in stock, which can drive a \
     switch.
 
-    This library provides tools to chain deeper into a binding's case by applying the \
-    `@CasePathable` macro.
+    By applying the `@CaseBindable` macro to the enum you can switch over a binding's cases \
+    directly, and each case is handed a binding to its associated value.
     """
 
-  @CasePathable
+  @CaseBindable
   enum Status {
     case inStock(quantity: Int)
     case outOfStock(isOnBackOrder: Bool)
@@ -89,17 +89,13 @@ class EnumControlsViewController: UIViewController, UIKitCaseStudy {
       inStockStack.isHidden = !status.is(\.inStock)
       outOfStockStack.isHidden = !status.is(\.outOfStock)
 
-      switch status {
-      case .inStock:
-        if let quantity = $status.inStock {
-          quantityLabel.text = "Quantity: \(quantity.wrappedValue)"
-          quantityStepper.bind(value: quantity.asDouble)
-        }
+      switch $status.cases {
+      case .inStock(let $quantity):
+        quantityLabel.text = "Quantity: \($quantity.wrappedValue)"
+        quantityStepper.bind(value: $quantity.asDouble)
 
-      case .outOfStock:
-        if let isOnBackOrder = $status.outOfStock {
-          isOnBackOrderSwitch.bind(isOn: isOnBackOrder)
-        }
+      case .outOfStock(let $isOnBackOrder):
+        isOnBackOrderSwitch.bind(isOn: $isOnBackOrder)
       }
     }
   }

--- a/Examples/Inventory/Item.swift
+++ b/Examples/Inventory/Item.swift
@@ -7,7 +7,7 @@ struct Item: Equatable, Identifiable {
   var name: String
   var status: Status
 
-  @CasePathable
+  @CaseBindable
   enum Status: Equatable {
     case inStock(quantity: Int)
     case outOfStock(isOnBackOrder: Bool)
@@ -36,7 +36,7 @@ struct Item: Equatable, Identifiable {
     static let white = Self(name: "White", red: 1, green: 1, blue: 1)
 
     var swiftUIColor: SwiftUI.Color {
-      SwiftUI.Color(red: self.red, green: self.green, blue: self.blue)
+      SwiftUI.Color(red: red, green: green, blue: blue)
     }
   }
 }
@@ -46,9 +46,9 @@ struct ItemView: View {
 
   var body: some View {
     Form {
-      TextField("Name", text: self.$item.name)
+      TextField("Name", text: $item.name)
 
-      Picker(selection: self.$item.color, label: Text("Color")) {
+      Picker(selection: $item.color, label: Text("Color")) {
         Text("None")
           .tag(Item.Color?.none)
 
@@ -58,42 +58,37 @@ struct ItemView: View {
         }
       }
 
-      switch self.item.status {
-      case .inStock:
-        self.$item.status.inStock.map { $quantity in
-          Section {
-            Stepper("Quantity: \(quantity)", value: $quantity)
-            Button("Mark as sold out") {
-              withAnimation {
-                self.item.status = .outOfStock(isOnBackOrder: false)
-              }
+      switch $item.status {
+      case .inStock(let $quantity):
+        Section {
+          Stepper("Quantity: \($quantity.wrappedValue)", value: $quantity)
+          Button("Mark as sold out") {
+            withAnimation {
+              item.status = .outOfStock(isOnBackOrder: false)
             }
-          } header: {
-            Text("In stock")
           }
-          .transition(.opacity)
+        } header: {
+          Text("In stock")
         }
-      case .outOfStock:
-        self.$item.status.outOfStock.map { $isOnBackOrder in
-          Section {
-            Toggle("Is on back order?", isOn: $isOnBackOrder)
-            Button("Back in stock!") {
-              withAnimation {
-                self.item.status = .inStock(quantity: 1)
-              }
+        .transition(.opacity)
+      case .outOfStock(let $isOnBackOrder):
+        Section {
+          Toggle("Is on back order?", isOn: $isOnBackOrder)
+          Button("Back in stock!") {
+            withAnimation {
+              item.status = .inStock(quantity: 1)
             }
-          } header: {
-            Text("Out of stock")
           }
-          .transition(.opacity)
+        } header: {
+          Text("Out of stock")
         }
+        .transition(.opacity)
       }
     }
   }
 }
 
 #Preview {
-  WithState(initialValue: Item(color: nil, name: "", status: .inStock(quantity: 1))) { $item in
-    ItemView(item: $item)
-  }
+  @Previewable @State var item = Item(color: nil, name: "", status: .inStock(quantity: 1))
+  ItemView(item: $item)
 }

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "9eae0023c77adbdd72d4c48ca2164e3b20aa6217213b263124853c2b896953c7",
+  "originHash" : "523f4d3bfac83b1974e090abdff3a43d504f426e2aa266ba098c8873d197a79f",
   "pins" : [
     {
       "identity" : "swift-case-paths",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "branch" : "macro-support",
-        "revision" : "6e91f6fc0e717ec407a69274e3a871b60940bed8"
+        "revision" : "1197e80bc7e4b177051b6869ef93d8ac3ad677da",
+        "version" : "1.8.0"
       }
     },
     {
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "cb281f343fd953280336dcbd3822cdf47c182f5b",
-        "version" : "1.10.0"
+        "revision" : "401bf70d95bfe8db2a1dc619f9e175a85c089321",
+        "version" : "1.10.1"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "9d206b1f9cc74f0eb39838df6ef86f47f3e8dfaf16122ceeb6dc2742dcecfde2",
+  "originHash" : "9eae0023c77adbdd72d4c48ca2164e3b20aa6217213b263124853c2b896953c7",
   "pins" : [
     {
       "identity" : "swift-case-paths",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "6989976265be3f8d2b5802c722f9ba168e227c71",
-        "version" : "1.7.2"
+        "branch" : "macro-support",
+        "revision" : "6e91f6fc0e717ec407a69274e3a871b60940bed8"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections",
       "state" : {
-        "revision" : "7b847a3b7008b2dc2f47ca3110d8c782fb2e5c7e",
-        "version" : "1.3.0"
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-concurrency-extras",
       "state" : {
-        "revision" : "5a3825302b1a0d744183200915a47b508c828e6f",
-        "version" : "1.3.2"
+        "revision" : "a90e2e40a7a840a853dd29e57cbef5dbb72c9d5b",
+        "version" : "1.4.0"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-custom-dump",
       "state" : {
-        "revision" : "82645ec760917961cfa08c9c0c7104a57a0fa4b1",
-        "version" : "1.3.3"
+        "revision" : "b9b59eb58c946236d6f16305c576ad194c36444e",
+        "version" : "1.6.0"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-docc-plugin",
       "state" : {
-        "revision" : "3e4f133a77e644a5812911a0513aeb7288b07d06",
-        "version" : "1.4.5"
+        "revision" : "647c708be89f834fa6a6d4945442793a77ddf5b6",
+        "version" : "1.5.0"
       }
     },
     {
@@ -56,12 +56,30 @@
       }
     },
     {
+      "identity" : "swift-macro-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-macro-testing",
+      "state" : {
+        "revision" : "2e494c632d510715c96a694ff25e2a8d4ac3f64b",
+        "version" : "0.6.5"
+      }
+    },
+    {
       "identity" : "swift-perception",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-perception",
       "state" : {
-        "revision" : "30721accd0370d7c9cb5bd0f7cdf5a1a767b383d",
-        "version" : "2.0.8"
+        "revision" : "25ac73741c3436605d61eceb5207e896973918e7",
+        "version" : "2.0.10"
+      }
+    },
+    {
+      "identity" : "swift-snapshot-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
+      "state" : {
+        "revision" : "ad5e3190cc63dc288f28546f9c6827efc1e9d495",
+        "version" : "1.19.2"
       }
     },
     {
@@ -69,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "4799286537280063c85a32f09884cfbca301b1a1",
-        "version" : "602.0.0"
+        "revision" : "79e4b74a295b6eb74a8b585e3a39d29e70c1dbd1",
+        "version" : "603.0.2"
       }
     },
     {
@@ -78,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
       "state" : {
-        "revision" : "4c27acf5394b645b70d8ba19dc249c0472d5f618",
-        "version" : "1.7.0"
+        "revision" : "cb281f343fd953280336dcbd3822cdf47c182f5b",
+        "version" : "1.10.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,6 @@
 // swift-tools-version: 6.1
 
+import CompilerPluginSupport
 import PackageDescription
 
 #if canImport(FoundationEssentials)
@@ -46,18 +47,36 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-collections", from: "1.0.0"),
-    .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.0.0"),
-    .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "1.5.6"),
+    .package(url: "https://github.com/pointfreeco/swift-case-paths", branch: "macro-support"),
     .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.2.0"),
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.3.2"),
     .package(url: "https://github.com/pointfreeco/swift-perception", "1.3.4"..<"3.0.0"),
-    .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.4.1"),
     .package(url: "https://github.com/pointfreeco/swift-sharing", from: "2.8.0"),
+    .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.4.1"),
+    .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.0.0"),
+    .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"605.0.0"),
   ],
   targets: [
+    .macro(
+      name: "SwiftNavigationMacros",
+      dependencies: [
+        .product(name: "CasePathsMacrosSupport", package: "swift-case-paths"),
+        .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
+        .product(name: "SwiftDiagnostics", package: "swift-syntax"),
+        .product(name: "SwiftSyntax", package: "swift-syntax"),
+        .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
+        .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+      ]
+    ),
     .target(
       name: "SwiftNavigation",
       dependencies: [
+        .target(
+          name: "SwiftNavigationMacros",
+          condition: .when(traits: [
+            "CasePaths"
+          ])
+        ),
         .product(
           name: "CasePaths",
           package: "swift-case-paths",
@@ -148,7 +167,7 @@ package.traits.insert(
   )
 )
 
-for target in package.targets {
+for target in package.targets where target.name != "SwiftNavigationMacros" {
   target.swiftSettings = target.swiftSettings ?? []
   target.swiftSettings?.append(contentsOf: [
     .enableUpcomingFeature("ExistentialAny"),
@@ -158,4 +177,19 @@ for target in package.targets {
     .enableUpcomingFeature("MemberImportVisibility"),
     .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
   ])
+}
+
+if ProcessInfo.processInfo.environment["OMIT_MACRO_TESTS"] == nil {
+  package.dependencies.append(
+    .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.6.0")
+  )
+  package.targets.append(
+    .testTarget(
+      name: "SwiftNavigationMacrosTests",
+      dependencies: [
+        "SwiftNavigationMacros",
+        .product(name: "MacroTesting", package: "swift-macro-testing"),
+      ]
+    )
+  )
 }

--- a/Package.swift
+++ b/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-collections", from: "1.0.0"),
-    .package(url: "https://github.com/pointfreeco/swift-case-paths", branch: "macro-support"),
+    .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "1.8.0"),
     .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.2.0"),
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.3.2"),
     .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.6.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -50,6 +50,7 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-case-paths", branch: "macro-support"),
     .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.2.0"),
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.3.2"),
+    .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.6.0"),
     .package(url: "https://github.com/pointfreeco/swift-perception", "1.3.4"..<"3.0.0"),
     .package(url: "https://github.com/pointfreeco/swift-sharing", from: "2.8.0"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.4.1"),
@@ -57,17 +58,6 @@ let package = Package(
     .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"605.0.0"),
   ],
   targets: [
-    .macro(
-      name: "SwiftNavigationMacros",
-      dependencies: [
-        .product(name: "CasePathsMacrosSupport", package: "swift-case-paths"),
-        .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
-        .product(name: "SwiftDiagnostics", package: "swift-syntax"),
-        .product(name: "SwiftSyntax", package: "swift-syntax"),
-        .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
-        .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
-      ]
-    ),
     .target(
       name: "SwiftNavigation",
       dependencies: [
@@ -106,6 +96,24 @@ let package = Package(
         .product(name: "IssueReportingTestSupport", package: "xctest-dynamic-overlay"),
       ]
     ),
+    .macro(
+      name: "SwiftNavigationMacros",
+      dependencies: [
+        .product(name: "CasePathsMacrosSupport", package: "swift-case-paths"),
+        .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
+        .product(name: "SwiftDiagnostics", package: "swift-syntax"),
+        .product(name: "SwiftSyntax", package: "swift-syntax"),
+        .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
+        .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+      ]
+    ),
+    .testTarget(
+      name: "SwiftNavigationMacrosTests",
+      dependencies: [
+        "SwiftNavigationMacros",
+        .product(name: "MacroTesting", package: "swift-macro-testing"),
+      ]
+    ),
     .target(
       name: "SwiftUINavigation",
       dependencies: [
@@ -139,17 +147,17 @@ let package = Package(
     .target(
       name: "UIKitNavigationShim"
     ),
-    .target(
-      name: "AppKitNavigation",
-      dependencies: [
-        "SwiftNavigation"
-      ]
-    ),
     .testTarget(
       name: "UIKitNavigationTests",
       dependencies: [
         "UIKitNavigation",
         .product(name: "IssueReportingTestSupport", package: "xctest-dynamic-overlay"),
+      ]
+    ),
+    .target(
+      name: "AppKitNavigation",
+      dependencies: [
+        "SwiftNavigation"
       ]
     ),
   ],
@@ -167,7 +175,7 @@ package.traits.insert(
   )
 )
 
-for target in package.targets where target.name != "SwiftNavigationMacros" {
+for target in package.targets {
   target.swiftSettings = target.swiftSettings ?? []
   target.swiftSettings?.append(contentsOf: [
     .enableUpcomingFeature("ExistentialAny"),
@@ -177,19 +185,4 @@ for target in package.targets where target.name != "SwiftNavigationMacros" {
     .enableUpcomingFeature("MemberImportVisibility"),
     .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
   ])
-}
-
-if ProcessInfo.processInfo.environment["OMIT_MACRO_TESTS"] == nil {
-  package.dependencies.append(
-    .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.6.0")
-  )
-  package.targets.append(
-    .testTarget(
-      name: "SwiftNavigationMacrosTests",
-      dependencies: [
-        "SwiftNavigationMacros",
-        .product(name: "MacroTesting", package: "swift-macro-testing"),
-      ]
-    )
-  )
 }

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -1,5 +1,7 @@
 // swift-tools-version: 6.0
 
+import CompilerPluginSupport
+import Foundation
 import PackageDescription
 
 let package = Package(
@@ -30,17 +32,30 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-collections", from: "1.0.0"),
-    .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.0.0"),
-    .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "1.5.6"),
+    .package(url: "https://github.com/pointfreeco/swift-case-paths", branch: "macro-support"),
     .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.2.0"),
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.3.2"),
     .package(url: "https://github.com/pointfreeco/swift-perception", "1.3.4"..<"3.0.0"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.4.1"),
+    .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.0.0"),
+    .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"605.0.0"),
   ],
   targets: [
+    .macro(
+      name: "SwiftNavigationMacros",
+      dependencies: [
+        .product(name: "CasePathsMacrosSupport", package: "swift-case-paths"),
+        .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
+        .product(name: "SwiftDiagnostics", package: "swift-syntax"),
+        .product(name: "SwiftSyntax", package: "swift-syntax"),
+        .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
+        .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+      ]
+    ),
     .target(
       name: "SwiftNavigation",
       dependencies: [
+        "SwiftNavigationMacros",
         .product(name: "CasePaths", package: "swift-case-paths"),
         .product(name: "CustomDump", package: "swift-custom-dump"),
         .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
@@ -101,7 +116,7 @@ let package = Package(
   swiftLanguageModes: [.v6]
 )
 
-for target in package.targets {
+for target in package.targets where target.name != "SwiftNavigationMacros" {
   target.swiftSettings = target.swiftSettings ?? []
   target.swiftSettings?.append(contentsOf: [
     .define("CasePaths"),
@@ -112,4 +127,19 @@ for target in package.targets {
     .enableUpcomingFeature("MemberImportVisibility"),
     .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
   ])
+}
+
+if ProcessInfo.processInfo.environment["OMIT_MACRO_TESTS"] == nil {
+  package.dependencies.append(
+    .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.6.0")
+  )
+  package.targets.append(
+    .testTarget(
+      name: "SwiftNavigationMacrosTests",
+      dependencies: [
+        "SwiftNavigationMacros",
+        .product(name: "MacroTesting", package: "swift-macro-testing"),
+      ]
+    )
+  )
 }

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -77,6 +77,7 @@ let package = Package(
       name: "SwiftNavigationMacrosTests",
       dependencies: [
         "SwiftNavigationMacros",
+        .product(name: "CasePathsMacrosSupport", package: "swift-case-paths"),
         .product(name: "MacroTesting", package: "swift-macro-testing"),
       ]
     ),

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -32,7 +32,7 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-collections", from: "1.0.0"),
-    .package(url: "https://github.com/pointfreeco/swift-case-paths", branch: "macro-support"),
+    .package(url: "https://github.com/pointfreeco/swift-case-paths", from: "1.8.0"),
     .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.2.0"),
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.3.2"),
     .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.6.0"),

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -35,23 +35,13 @@ let package = Package(
     .package(url: "https://github.com/pointfreeco/swift-case-paths", branch: "macro-support"),
     .package(url: "https://github.com/pointfreeco/swift-concurrency-extras", from: "1.2.0"),
     .package(url: "https://github.com/pointfreeco/swift-custom-dump", from: "1.3.2"),
+    .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.6.0"),
     .package(url: "https://github.com/pointfreeco/swift-perception", "1.3.4"..<"3.0.0"),
     .package(url: "https://github.com/pointfreeco/xctest-dynamic-overlay", from: "1.4.1"),
     .package(url: "https://github.com/swiftlang/swift-docc-plugin", from: "1.0.0"),
     .package(url: "https://github.com/swiftlang/swift-syntax", "509.0.0"..<"605.0.0"),
   ],
   targets: [
-    .macro(
-      name: "SwiftNavigationMacros",
-      dependencies: [
-        .product(name: "CasePathsMacrosSupport", package: "swift-case-paths"),
-        .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
-        .product(name: "SwiftDiagnostics", package: "swift-syntax"),
-        .product(name: "SwiftSyntax", package: "swift-syntax"),
-        .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
-        .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
-      ]
-    ),
     .target(
       name: "SwiftNavigation",
       dependencies: [
@@ -70,6 +60,24 @@ let package = Package(
       dependencies: [
         "SwiftNavigation",
         .product(name: "IssueReportingTestSupport", package: "xctest-dynamic-overlay"),
+      ]
+    ),
+    .macro(
+      name: "SwiftNavigationMacros",
+      dependencies: [
+        .product(name: "CasePathsMacrosSupport", package: "swift-case-paths"),
+        .product(name: "SwiftCompilerPlugin", package: "swift-syntax"),
+        .product(name: "SwiftDiagnostics", package: "swift-syntax"),
+        .product(name: "SwiftSyntax", package: "swift-syntax"),
+        .product(name: "SwiftSyntaxBuilder", package: "swift-syntax"),
+        .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+      ]
+    ),
+    .testTarget(
+      name: "SwiftNavigationMacrosTests",
+      dependencies: [
+        "SwiftNavigationMacros",
+        .product(name: "MacroTesting", package: "swift-macro-testing"),
       ]
     ),
     .target(
@@ -99,12 +107,6 @@ let package = Package(
     .target(
       name: "UIKitNavigationShim"
     ),
-    .target(
-      name: "AppKitNavigation",
-      dependencies: [
-        "SwiftNavigation"
-      ]
-    ),
     .testTarget(
       name: "UIKitNavigationTests",
       dependencies: [
@@ -112,11 +114,17 @@ let package = Package(
         .product(name: "IssueReportingTestSupport", package: "xctest-dynamic-overlay"),
       ]
     ),
+    .target(
+      name: "AppKitNavigation",
+      dependencies: [
+        "SwiftNavigation"
+      ]
+    ),
   ],
   swiftLanguageModes: [.v6]
 )
 
-for target in package.targets where target.name != "SwiftNavigationMacros" {
+for target in package.targets {
   target.swiftSettings = target.swiftSettings ?? []
   target.swiftSettings?.append(contentsOf: [
     .define("CasePaths"),
@@ -127,19 +135,4 @@ for target in package.targets where target.name != "SwiftNavigationMacros" {
     .enableUpcomingFeature("MemberImportVisibility"),
     .enableUpcomingFeature("NonisolatedNonsendingByDefault"),
   ])
-}
-
-if ProcessInfo.processInfo.environment["OMIT_MACRO_TESTS"] == nil {
-  package.dependencies.append(
-    .package(url: "https://github.com/pointfreeco/swift-macro-testing", from: "0.6.0")
-  )
-  package.targets.append(
-    .testTarget(
-      name: "SwiftNavigationMacrosTests",
-      dependencies: [
-        "SwiftNavigationMacros",
-        .product(name: "MacroTesting", package: "swift-macro-testing"),
-      ]
-    )
-  )
 }

--- a/Sources/SwiftNavigation/CaseBindable.swift
+++ b/Sources/SwiftNavigation/CaseBindable.swift
@@ -1,0 +1,142 @@
+#if CasePaths
+  public import CasePaths
+
+  public protocol CaseBindable: CasePathable {
+    associatedtype UIBindingEnumeration
+
+    static func _$caseBinding(_ binding: UIBinding<Self>) -> UIBindingEnumeration
+
+    #if canImport(SwiftUI)
+      associatedtype BindingEnumeration
+
+      static func _$caseBinding(_ binding: SwiftUI.Binding<Self>) -> BindingEnumeration
+    #endif
+  }
+
+  @attached(extension, conformances: CasePathable, CasePathIterable, CaseBindable)
+  @attached(
+    member,
+    names: named(AllCasePaths),
+    named(allCasePaths),
+    named(_$Element),
+    named(UIBindingEnumeration),
+    named(BindingEnumeration),
+    named(_$caseBinding)
+  )
+  public macro CaseBindable() =
+    #externalMacro(module: "SwiftNavigationMacros", type: "CaseBindableMacro")
+
+  extension UIBinding where Value: CaseBindable {
+    public var cases: Value.UIBindingEnumeration {
+      Value._$caseBinding(self)
+    }
+  }
+
+  extension UIBinding {
+    public subscript<Member: CaseBindable>(
+      dynamicMember keyPath: WritableKeyPath<Value, Member>
+    ) -> Member.UIBindingEnumeration {
+      let binding: UIBinding<Member> = self[dynamicMember: keyPath]
+      return binding.cases
+    }
+  }
+
+  extension UIBindable {
+    public subscript<Member: CaseBindable>(
+      dynamicMember keyPath: ReferenceWritableKeyPath<Value, Member>
+    ) -> Member.UIBindingEnumeration where Value: AnyObject {
+      let binding: UIBinding<Member> = self[dynamicMember: keyPath]
+      return binding.cases
+    }
+  }
+
+  extension UIBinding where Value: CasePathable {
+    public func _$case<Member>(
+      _ keyPath: KeyPath<Value.AllCasePaths, AnyCasePath<Value, Member>>
+    ) -> UIBinding<Member> {
+      self[dynamicMember: keyPath]!
+    }
+  }
+
+  #if canImport(SwiftUI)
+    public import SwiftUI
+
+    public typealias _Binding<Value> = SwiftUI.Binding<Value>
+
+    extension SwiftUI.Binding where Value: CaseBindable {
+      public var cases: Value.BindingEnumeration {
+        Value._$caseBinding(self)
+      }
+    }
+
+    extension SwiftUI.Binding {
+      public subscript<Member: CaseBindable>(
+        dynamicMember keyPath: WritableKeyPath<Value, Member>
+      ) -> Member.BindingEnumeration {
+        let binding: SwiftUI.Binding<Member> = self[dynamicMember: keyPath]
+        return binding.cases
+      }
+    }
+
+    @available(iOS 17, macOS 14, tvOS 17, watchOS 10, *)
+    extension SwiftUI.Bindable {
+      public subscript<Member: CaseBindable>(
+        dynamicMember keyPath: ReferenceWritableKeyPath<Value, Member>
+      ) -> Member.BindingEnumeration where Value: AnyObject {
+        let binding: SwiftUI.Binding<Member> = self[dynamicMember: keyPath]
+        return binding.cases
+      }
+    }
+
+    extension SwiftUI.Binding {
+      public var _$wrappedValue: Value { wrappedValue }
+    }
+
+    extension SwiftUI.Binding where Value: CasePathable {
+      public func _$case<Member>(
+        _ keyPath: KeyPath<Value.AllCasePaths, AnyCasePath<Value, Member>>
+      ) -> SwiftUI.Binding<Member> {
+        SwiftUI.Binding<Member>(_unwrapping: self[_case: keyPath])!
+      }
+    }
+
+    extension SwiftUI.Binding {
+      fileprivate init?(_unwrapping base: SwiftUI.Binding<Value?>) {
+        guard let value = base.wrappedValue else { return nil }
+        self = base[_default: _CaseDefault(value)]
+      }
+    }
+
+    extension CasePathable {
+      fileprivate subscript<Member>(
+        _case keyPath: KeyPath<AllCasePaths, AnyCasePath<Self, Member>>
+      ) -> Member? {
+        get { Self.allCasePaths[keyPath: keyPath].extract(from: self) }
+        set {
+          guard let newValue else { return }
+          self = Self.allCasePaths[keyPath: keyPath].embed(newValue)
+        }
+      }
+    }
+
+    extension Optional {
+      fileprivate subscript(_default defaultValue: _CaseDefault<Wrapped>) -> Wrapped {
+        get {
+          defaultValue.value = self ?? defaultValue.value
+          return defaultValue.value
+        }
+        set {
+          defaultValue.value = newValue
+          if self != nil { self = newValue }
+        }
+      }
+    }
+
+    private final class _CaseDefault<Value>: Hashable {
+      var value: Value
+      init(_ value: Value) { self.value = value }
+      static func == (lhs: _CaseDefault, rhs: _CaseDefault) -> Bool { lhs === rhs }
+      func hash(into hasher: inout Hasher) { hasher.combine(ObjectIdentifier(self)) }
+    }
+  #endif
+#endif

--- a/Sources/SwiftNavigationMacros/CaseBindableMacro.swift
+++ b/Sources/SwiftNavigationMacros/CaseBindableMacro.swift
@@ -1,8 +1,8 @@
 import CasePathsMacrosSupport
 import SwiftDiagnostics
-import SwiftSyntax
+public import SwiftSyntax
 import SwiftSyntaxBuilder
-import SwiftSyntaxMacros
+public import SwiftSyntaxMacros
 
 public enum CaseBindableMacro {
   static let moduleName = "SwiftNavigation"

--- a/Sources/SwiftNavigationMacros/CaseBindableMacro.swift
+++ b/Sources/SwiftNavigationMacros/CaseBindableMacro.swift
@@ -1,0 +1,137 @@
+import CasePathsMacrosSupport
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxBuilder
+import SwiftSyntaxMacros
+
+public enum CaseBindableMacro {
+  static let moduleName = "SwiftNavigation"
+}
+
+extension CaseBindableMacro: ExtensionMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    attachedTo declaration: some DeclGroupSyntax,
+    providingExtensionsOf type: some TypeSyntaxProtocol,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [ExtensionDeclSyntax] {
+    guard let enumDecl = declaration.as(EnumDeclSyntax.self) else {
+      return []
+    }
+
+    var extensions = try CasePathableMacro.expansion(
+      of: node,
+      attachedTo: declaration,
+      providingExtensionsOf: type,
+      conformingTo: protocols,
+      in: context
+    )
+
+    let conformsToCaseBindable =
+      enumDecl.inheritanceClause?.inheritedTypes.contains {
+        ["CaseBindable", "\(moduleName).CaseBindable"].contains($0.type.trimmedDescription)
+      } ?? false
+    if !conformsToCaseBindable {
+      let caseBindableExtension: DeclSyntax = """
+        \(declaration.attributes.availability)extension \(type.trimmed): \
+        \(raw: moduleName).CaseBindable {}
+        """
+      extensions.append(caseBindableExtension.cast(ExtensionDeclSyntax.self))
+    }
+
+    return extensions
+  }
+}
+
+extension CaseBindableMacro: MemberMacro {
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    conformingTo protocols: [TypeSyntax],
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    try expansion(of: node, providingMembersOf: declaration, in: context)
+  }
+
+  public static func expansion(
+    of node: AttributeSyntax,
+    providingMembersOf declaration: some DeclGroupSyntax,
+    in context: some MacroExpansionContext
+  ) throws -> [DeclSyntax] {
+    guard let enumDecl = declaration.as(EnumDeclSyntax.self) else {
+      throw DiagnosticsError(
+        diagnostics: [
+          Diagnostic(
+            node: declaration,
+            message: MacroExpansionErrorMessage("'@CaseBindable' can only be applied to enums")
+          )
+        ]
+      )
+    }
+
+    var decls = try CasePathableMacro.expansion(
+      of: node,
+      providingMembersOf: declaration,
+      in: context
+    )
+
+    let elements = enumDecl.memberBlock.members
+      .flatMap { $0.decl.as(EnumCaseDeclSyntax.self)?.elements ?? [] }
+
+    var uiBindingCases: [String] = []
+    var uiSwitchCases: [String] = []
+    var bindingCases: [String] = []
+    var bindingSwitchCases: [String] = []
+
+    for element in elements {
+      let name = element.name.trimmed
+      let hasPayload = element.parameterClause.map { !$0.parameters.isEmpty } ?? false
+      if hasPayload {
+        let valueType = CasePathableMacro.valueType(for: element)
+        uiBindingCases.append("case \(name)(\(moduleName).UIBinding<\(valueType)>)")
+        bindingCases.append("case \(name)(\(moduleName)._Binding<\(valueType)>)")
+        uiSwitchCases.append("case .\(name): return .\(name)(binding._$case(\\.\(name)))")
+        bindingSwitchCases.append("case .\(name): return .\(name)(binding._$case(\\.\(name)))")
+      } else {
+        uiBindingCases.append("case \(name)")
+        bindingCases.append("case \(name)")
+        uiSwitchCases.append("case .\(name): return .\(name)")
+        bindingSwitchCases.append("case .\(name): return .\(name)")
+      }
+    }
+
+    decls.append(
+      """
+      public enum UIBindingEnumeration {
+      \(raw: uiBindingCases.map { "\($0)\n" }.joined())}
+      """
+    )
+    decls.append(
+      """
+      public static func _$caseBinding(
+      _ binding: \(raw: moduleName).UIBinding<Self>
+      ) -> UIBindingEnumeration {
+      switch binding.wrappedValue {
+      \(raw: uiSwitchCases.map { "\($0)\n" }.joined())}
+      }
+      """
+    )
+    decls.append(
+      """
+      #if canImport(SwiftUI)
+      public enum BindingEnumeration {
+      \(raw: bindingCases.map { "\($0)\n" }.joined())}
+      public static func _$caseBinding(
+      _ binding: \(raw: moduleName)._Binding<Self>
+      ) -> BindingEnumeration {
+      switch binding._$wrappedValue {
+      \(raw: bindingSwitchCases.map { "\($0)\n" }.joined())}
+      }
+      #endif
+      """
+    )
+
+    return decls
+  }
+}

--- a/Sources/SwiftNavigationMacros/Plugin.swift
+++ b/Sources/SwiftNavigationMacros/Plugin.swift
@@ -1,0 +1,9 @@
+import SwiftCompilerPlugin
+import SwiftSyntaxMacros
+
+@main
+struct SwiftNavigationPlugin: CompilerPlugin {
+  let providingMacros: [Macro.Type] = [
+    CaseBindableMacro.self
+  ]
+}

--- a/Sources/SwiftNavigationMacros/Plugin.swift
+++ b/Sources/SwiftNavigationMacros/Plugin.swift
@@ -3,7 +3,7 @@ import SwiftSyntaxMacros
 
 @main
 struct SwiftNavigationPlugin: CompilerPlugin {
-  let providingMacros: [Macro.Type] = [
+  let providingMacros: [any Macro.Type] = [
     CaseBindableMacro.self
   ]
 }

--- a/Sources/SwiftNavigationMacros/Support.swift
+++ b/Sources/SwiftNavigationMacros/Support.swift
@@ -1,0 +1,115 @@
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
+extension AttributeListSyntax {
+  var availability: AttributeListSyntax? {
+    var elements = [AttributeListSyntax.Element]()
+    for element in self {
+      if let availability = element.availability {
+        elements.append(availability)
+      }
+    }
+    if elements.isEmpty {
+      return nil
+    }
+    return AttributeListSyntax(elements)
+  }
+}
+
+extension AttributeListSyntax.Element {
+  var availability: AttributeListSyntax.Element? {
+    switch self {
+    case .attribute(let attribute):
+      if let availability = attribute.availability {
+        return .attribute(availability)
+      }
+    case .ifConfigDecl(let ifConfig):
+      if let availability = ifConfig.availability {
+        return .ifConfigDecl(availability)
+      }
+    @unknown default: return nil
+    }
+    return nil
+  }
+}
+
+extension AttributeSyntax {
+  var availability: AttributeSyntax? {
+    if attributeName.identifier == "available" {
+      return self
+    } else {
+      return nil
+    }
+  }
+}
+
+extension IfConfigClauseSyntax {
+  var availability: IfConfigClauseSyntax? {
+    if let availability = elements?.availability {
+      return with(\.elements, availability)
+    } else {
+      return nil
+    }
+  }
+
+  var clonedAsIf: IfConfigClauseSyntax {
+    detached.with(\.poundKeyword, .poundIfToken())
+  }
+}
+
+extension IfConfigClauseSyntax.Elements {
+  var availability: IfConfigClauseSyntax.Elements? {
+    switch self {
+    case .attributes(let attributes):
+      if let availability = attributes.availability {
+        return .attributes(availability)
+      } else {
+        return nil
+      }
+    default:
+      return nil
+    }
+  }
+}
+
+extension IfConfigDeclSyntax {
+  var availability: IfConfigDeclSyntax? {
+    var elements = [IfConfigClauseListSyntax.Element]()
+    for clause in clauses {
+      if let availability = clause.availability {
+        if elements.isEmpty {
+          elements.append(availability.clonedAsIf)
+        } else {
+          elements.append(availability)
+        }
+      }
+    }
+    if elements.isEmpty {
+      return nil
+    } else {
+      return with(\.clauses, IfConfigClauseListSyntax(elements))
+    }
+  }
+}
+
+extension TypeSyntax {
+  fileprivate var identifier: String? {
+    for token in tokens(viewMode: .all) {
+      switch token.tokenKind {
+      case .identifier(let identifier):
+        return identifier
+      default:
+        break
+      }
+    }
+    return nil
+  }
+}
+
+extension SyntaxStringInterpolation {
+  mutating func appendInterpolation<Node: SyntaxProtocol>(_ node: Node?) {
+    if let node {
+      self.appendInterpolation(node)
+    }
+  }
+}

--- a/SwiftNavigation.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SwiftNavigation.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9c90a635de86ec9c9dfc94685a4463ca6fff1b5e98474c62cd28d36b5b67fe89",
+  "originHash" : "6a2b8a399b4ecd341ac962bb4e3d8cdd1e82aa4d176a1dee24abf4f793e90274",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "5928286acce13def418ec36d05a001a9641086f2",
         "version" : "1.0.3"
+      }
+    },
+    {
+      "identity" : "swift-case-paths",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-case-paths",
+      "state" : {
+        "branch" : "macro-support",
+        "revision" : "6e91f6fc0e717ec407a69274e3a871b60940bed8"
       }
     },
     {

--- a/SwiftNavigation.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SwiftNavigation.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6a2b8a399b4ecd341ac962bb4e3d8cdd1e82aa4d176a1dee24abf4f793e90274",
+  "originHash" : "d41c8b0a6ba5d587f961e7f69d2abad4bb521d63202170099ffba66afe6d025a",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "branch" : "macro-support",
-        "revision" : "6e91f6fc0e717ec407a69274e3a871b60940bed8"
+        "revision" : "1197e80bc7e4b177051b6869ef93d8ac3ad677da",
+        "version" : "1.8.0"
       }
     },
     {

--- a/SwiftNavigation.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SwiftNavigation.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,4 +1,5 @@
 {
+  "originHash" : "9c90a635de86ec9c9dfc94685a4463ca6fff1b5e98474c62cd28d36b5b67fe89",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -7,15 +8,6 @@
       "state" : {
         "revision" : "5928286acce13def418ec36d05a001a9641086f2",
         "version" : "1.0.3"
-      }
-    },
-    {
-      "identity" : "swift-case-paths",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-case-paths",
-      "state" : {
-        "revision" : "9810c8d6c2914de251e072312f01d3bf80071852",
-        "version" : "1.7.1"
       }
     },
     {
@@ -91,12 +83,30 @@
       }
     },
     {
+      "identity" : "swift-macro-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-macro-testing",
+      "state" : {
+        "revision" : "2e494c632d510715c96a694ff25e2a8d4ac3f64b",
+        "version" : "0.6.5"
+      }
+    },
+    {
       "identity" : "swift-perception",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-perception",
       "state" : {
         "revision" : "d924c62a70fca5f43872f286dbd7cef0957f1c01",
         "version" : "1.6.0"
+      }
+    },
+    {
+      "identity" : "swift-snapshot-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
+      "state" : {
+        "revision" : "ad5e3190cc63dc288f28546f9c6827efc1e9d495",
+        "version" : "1.19.2"
       }
     },
     {
@@ -127,5 +137,5 @@
       }
     }
   ],
-  "version" : 2
+  "version" : 3
 }

--- a/Tests/SwiftNavigationMacrosTests/CaseBindableMacroTests.swift
+++ b/Tests/SwiftNavigationMacrosTests/CaseBindableMacroTests.swift
@@ -1,19 +1,21 @@
 #if canImport(MacroTesting)
+  import CasePathsMacrosSupport
   import MacroTesting
+  import SnapshotTesting
   import SwiftNavigationMacros
-  import XCTest
+  import Testing
 
-  final class CaseBindableMacroTests: XCTestCase {
-    override func invokeTest() {
-      withMacroTesting(
-        // record: .failed,
-        macros: [CaseBindableMacro.self]
-      ) {
-        super.invokeTest()
-      }
-    }
-
-    func testBasics() {
+  @Suite(
+    .macros(
+      [
+        CaseBindableMacro.self,
+        CasePathableMacro.self,
+      ],
+      record: .failed
+    )
+  )
+  struct CaseBindableMacroTests {
+    @Test func basics() {
       assertMacro {
         """
         @CaseBindable
@@ -151,7 +153,7 @@
       }
     }
 
-    func testExistingCasePathable() {
+    @Test func casePathableOverlap() {
       assertMacro {
         """
         @CasePathable
@@ -163,10 +165,49 @@
         """
       } expansion: {
         #"""
-        @CasePathable
         enum Status {
           case inStock(quantity: Int)
           case discontinued
+
+          public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
+            public subscript(root: Status) -> CasePaths.PartialCaseKeyPath<Status> {
+              if root.is(\.inStock) {
+                return \.inStock
+              }
+              if root.is(\.discontinued) {
+                return \.discontinued
+              }
+              return \.never
+            }
+            public var inStock: CasePaths.AnyCasePath<Status, Int> {
+              ._$embed(Status.inStock) {
+                guard case let .inStock(v0) = $0 else {
+                  return nil
+                }
+                return v0
+              }
+            }
+            public var discontinued: CasePaths.AnyCasePath<Status, Void> {
+              ._$embed({
+                  Status.discontinued
+                }) {
+                guard case .discontinued = $0 else {
+                  return nil
+                }
+                return ()
+              }
+            }
+            public func makeIterator() -> Swift.IndexingIterator<[CasePaths.PartialCaseKeyPath<Status>]> {
+              var allCasePaths: [CasePaths.PartialCaseKeyPath<Status>] = []
+              allCasePaths.append(\.inStock)
+              allCasePaths.append(\.discontinued)
+              return allCasePaths.makeIterator()
+            }
+          }
+
+          public static var allCasePaths: AllCasePaths {
+            AllCasePaths()
+          }
 
           public enum UIBindingEnumeration {
             case inStock(SwiftNavigation.UIBinding<Int>)
@@ -202,24 +243,12 @@
           #endif
         }
 
+        extension Status: CasePaths.CasePathable, CasePaths.CasePathIterable {
+        }
+
         extension Status: SwiftNavigation.CaseBindable {
         }
         """#
-      }
-    }
-
-    func testNotAnEnum() {
-      assertMacro {
-        """
-        @CaseBindable
-        struct Status {}
-        """
-      } diagnostics: {
-        """
-        @CaseBindable
-        ╰─ 🛑 '@CaseBindable' can only be applied to enums
-        struct Status {}
-        """
       }
     }
   }

--- a/Tests/SwiftNavigationMacrosTests/CaseBindableMacroTests.swift
+++ b/Tests/SwiftNavigationMacrosTests/CaseBindableMacroTests.swift
@@ -1,0 +1,226 @@
+#if canImport(MacroTesting)
+  import MacroTesting
+  import SwiftNavigationMacros
+  import XCTest
+
+  final class CaseBindableMacroTests: XCTestCase {
+    override func invokeTest() {
+      withMacroTesting(
+        // record: .failed,
+        macros: [CaseBindableMacro.self]
+      ) {
+        super.invokeTest()
+      }
+    }
+
+    func testBasics() {
+      assertMacro {
+        """
+        @CaseBindable
+        enum Status {
+          case inStock(quantity: Int)
+          case outOfStock(isOnBackOrder: Bool)
+          case onSale(price: Int, discount: Int)
+          case discontinued
+        }
+        """
+      } expansion: {
+        #"""
+        enum Status {
+          case inStock(quantity: Int)
+          case outOfStock(isOnBackOrder: Bool)
+          case onSale(price: Int, discount: Int)
+          case discontinued
+
+          public struct AllCasePaths: CasePaths.CasePathReflectable, Swift.Sendable, Swift.Sequence {
+            public subscript(root: Status) -> CasePaths.PartialCaseKeyPath<Status> {
+              if root.is(\.inStock) {
+                return \.inStock
+              }
+              if root.is(\.outOfStock) {
+                return \.outOfStock
+              }
+              if root.is(\.onSale) {
+                return \.onSale
+              }
+              if root.is(\.discontinued) {
+                return \.discontinued
+              }
+              return \.never
+            }
+            public var inStock: CasePaths.AnyCasePath<Status, Int> {
+              ._$embed(Status.inStock) {
+                guard case let .inStock(v0) = $0 else {
+                  return nil
+                }
+                return v0
+              }
+            }
+            public var outOfStock: CasePaths.AnyCasePath<Status, Bool> {
+              ._$embed(Status.outOfStock) {
+                guard case let .outOfStock(v0) = $0 else {
+                  return nil
+                }
+                return v0
+              }
+            }
+            public var onSale: CasePaths.AnyCasePath<Status, (price: Int, discount: Int)> {
+              ._$embed(Status.onSale) {
+                guard case let .onSale(v0, v1) = $0 else {
+                  return nil
+                }
+                return (v0, v1)
+              }
+            }
+            public var discontinued: CasePaths.AnyCasePath<Status, Void> {
+              ._$embed({
+                  Status.discontinued
+                }) {
+                guard case .discontinued = $0 else {
+                  return nil
+                }
+                return ()
+              }
+            }
+            public func makeIterator() -> Swift.IndexingIterator<[CasePaths.PartialCaseKeyPath<Status>]> {
+              var allCasePaths: [CasePaths.PartialCaseKeyPath<Status>] = []
+              allCasePaths.append(\.inStock)
+              allCasePaths.append(\.outOfStock)
+              allCasePaths.append(\.onSale)
+              allCasePaths.append(\.discontinued)
+              return allCasePaths.makeIterator()
+            }
+          }
+
+          public static var allCasePaths: AllCasePaths {
+            AllCasePaths()
+          }
+
+          public enum UIBindingEnumeration {
+            case inStock(SwiftNavigation.UIBinding<Int>)
+            case outOfStock(SwiftNavigation.UIBinding<Bool>)
+            case onSale(SwiftNavigation.UIBinding<(price: Int, discount: Int)>)
+            case discontinued
+          }
+
+          public static func _$caseBinding(
+            _ binding: SwiftNavigation.UIBinding<Self>
+          ) -> UIBindingEnumeration {
+            switch binding.wrappedValue {
+            case .inStock:
+              return .inStock(binding._$case(\.inStock))
+            case .outOfStock:
+              return .outOfStock(binding._$case(\.outOfStock))
+            case .onSale:
+              return .onSale(binding._$case(\.onSale))
+            case .discontinued:
+              return .discontinued
+            }
+          }
+
+          #if canImport(SwiftUI)
+          public enum BindingEnumeration {
+            case inStock(SwiftNavigation._Binding<Int>)
+            case outOfStock(SwiftNavigation._Binding<Bool>)
+            case onSale(SwiftNavigation._Binding<(price: Int, discount: Int)>)
+            case discontinued
+          }
+          public static func _$caseBinding(
+            _ binding: SwiftNavigation._Binding<Self>
+          ) -> BindingEnumeration {
+            switch binding._$wrappedValue {
+            case .inStock:
+              return .inStock(binding._$case(\.inStock))
+            case .outOfStock:
+              return .outOfStock(binding._$case(\.outOfStock))
+            case .onSale:
+              return .onSale(binding._$case(\.onSale))
+            case .discontinued:
+              return .discontinued
+            }
+          }
+          #endif
+        }
+
+        extension Status: CasePaths.CasePathable, CasePaths.CasePathIterable {
+        }
+
+        extension Status: SwiftNavigation.CaseBindable {
+        }
+        """#
+      }
+    }
+
+    func testExistingCasePathable() {
+      assertMacro {
+        """
+        @CasePathable
+        @CaseBindable
+        enum Status {
+          case inStock(quantity: Int)
+          case discontinued
+        }
+        """
+      } expansion: {
+        #"""
+        @CasePathable
+        enum Status {
+          case inStock(quantity: Int)
+          case discontinued
+
+          public enum UIBindingEnumeration {
+            case inStock(SwiftNavigation.UIBinding<Int>)
+            case discontinued
+          }
+
+          public static func _$caseBinding(
+            _ binding: SwiftNavigation.UIBinding<Self>
+          ) -> UIBindingEnumeration {
+            switch binding.wrappedValue {
+            case .inStock:
+              return .inStock(binding._$case(\.inStock))
+            case .discontinued:
+              return .discontinued
+            }
+          }
+
+          #if canImport(SwiftUI)
+          public enum BindingEnumeration {
+            case inStock(SwiftNavigation._Binding<Int>)
+            case discontinued
+          }
+          public static func _$caseBinding(
+            _ binding: SwiftNavigation._Binding<Self>
+          ) -> BindingEnumeration {
+            switch binding._$wrappedValue {
+            case .inStock:
+              return .inStock(binding._$case(\.inStock))
+            case .discontinued:
+              return .discontinued
+            }
+          }
+          #endif
+        }
+
+        extension Status: SwiftNavigation.CaseBindable {
+        }
+        """#
+      }
+    }
+
+    func testNotAnEnum() {
+      assertMacro {
+        """
+        @CaseBindable
+        struct Status {}
+        """
+      } diagnostics: {
+        """
+        @CaseBindable
+        ╰─ 🛑 '@CaseBindable' can only be applied to enums
+        struct Status {}
+        """
+      }
+    }
+  }
+#endif

--- a/Tests/SwiftNavigationTests/CaseBindableTests.swift
+++ b/Tests/SwiftNavigationTests/CaseBindableTests.swift
@@ -1,0 +1,123 @@
+#if CasePaths
+  import CasePaths
+  import SwiftNavigation
+  import XCTest
+
+  #if canImport(SwiftUI)
+    import SwiftUI
+  #endif
+
+  final class CaseBindableTests: XCTestCase {
+    func testCasePathableConformance() {
+      let status = Status.inStock(quantity: 100)
+      XCTAssertEqual(status[case: \.inStock], 100)
+      XCTAssertNil(status[case: \.discontinued])
+    }
+
+    func testUIBindingEnumerationDerivesBinding() {
+      @UIBinding var status = Status.inStock(quantity: 100)
+      switch $status.cases {
+      case .inStock(let quantity):
+        XCTAssertEqual(quantity.wrappedValue, 100)
+        quantity.wrappedValue = 42
+      case .outOfStock, .onSale, .discontinued:
+        XCTFail("Expected 'inStock'")
+      }
+      XCTAssertEqual(status, .inStock(quantity: 42))
+    }
+
+    func testUIBindingEnumerationLabeledAndCaselessCases() {
+      @UIBinding var status = Status.outOfStock(isOnBackOrder: false)
+      switch $status.cases {
+      case .outOfStock(let isOnBackOrder):
+        isOnBackOrder.wrappedValue = true
+      case .inStock, .onSale, .discontinued:
+        XCTFail("Expected 'outOfStock'")
+      }
+      XCTAssertEqual(status, .outOfStock(isOnBackOrder: true))
+
+      status = .discontinued
+      switch $status.cases {
+      case .discontinued:
+        break
+      case .inStock, .outOfStock, .onSale:
+        XCTFail("Expected 'discontinued'")
+      }
+    }
+
+    func testUIBindingEnumerationMultipleAssociatedValues() {
+      @UIBinding var status = Status.onSale(price: 100, discount: 10)
+      switch $status.cases {
+      case .onSale(let sale):
+        XCTAssertEqual(sale.wrappedValue.price, 100)
+        sale.wrappedValue.discount = 25
+      case .inStock, .outOfStock, .discontinued:
+        XCTFail("Expected 'onSale'")
+      }
+      XCTAssertEqual(status, .onSale(price: 100, discount: 25))
+    }
+
+    func testUIBindingChainsIntoCaseBindableMember() {
+      @UIBinding var item = Item(name: "Widget", status: .inStock(quantity: 100))
+      let name: UIBinding<String> = $item.name
+      XCTAssertEqual(name.wrappedValue, "Widget")
+      switch $item.status {
+      case .inStock(let quantity):
+        quantity.wrappedValue = 9
+      case .outOfStock, .onSale, .discontinued:
+        XCTFail("Expected 'inStock'")
+      }
+      XCTAssertEqual(item.status, .inStock(quantity: 9))
+    }
+
+    #if canImport(SwiftUI)
+      @MainActor
+      func testBindingEnumerationDerivesBinding() {
+        let ref = Ref(status: .inStock(quantity: 100))
+        let binding = Binding(get: { ref.status }, set: { ref.status = $0 })
+        switch binding.cases {
+        case .inStock(let quantity):
+          XCTAssertEqual(quantity.wrappedValue, 100)
+          quantity.wrappedValue = 7
+        case .outOfStock, .discontinued, .onSale:
+          XCTFail("Expected 'inStock'")
+        }
+        XCTAssertEqual(ref.status, .inStock(quantity: 7))
+      }
+
+      @MainActor
+      func testBindingChainsIntoCaseBindableMember() {
+        let ref = Ref(status: .inStock(quantity: 100))
+        let item = Binding(
+          get: { Item(name: "Widget", status: ref.status) },
+          set: { ref.status = $0.status }
+        )
+        switch item.status {
+        case .inStock(let quantity):
+          quantity.wrappedValue = 3
+        case .outOfStock, .onSale, .discontinued:
+          XCTFail("Expected 'inStock'")
+        }
+        XCTAssertEqual(ref.status, .inStock(quantity: 3))
+      }
+    #endif
+  }
+
+  private struct Item {
+    var name: String
+    var status: Status
+  }
+
+  @CaseBindable
+  private enum Status: Equatable {
+    case inStock(quantity: Int)
+    case outOfStock(isOnBackOrder: Bool)
+    case onSale(price: Int, discount: Int)
+    case discontinued
+  }
+
+  private final class Ref: @unchecked Sendable {
+    var status: Status
+    init(status: Status) { self.status = status }
+  }
+#endif


### PR DESCRIPTION
Let's introduce a `@CaseBindable` macro, which adds a `@CasePathable` conformance and exhaustive switching over SwiftUI bindings (and the library's `UIBinding` type):

```swift
@CaseBindable
enum Status {
  case inStock(quantity: Int)
  case outOfStock(isOnBackOrder: Bool)
}

@State var item = Item()

switch $item.status {
case .inStock(let $quantity):
  Stepper("\($quantity.wrappedValue)", value: $quantity)
case .outOfStock(let $isOnBackOrder):
  Toggle("Is on back order?", isOn: $isOnBackOrder)
}
```

The `$` syntax isn't real projection, so we do need to explicitly call to `$quantity.wrappedValue` when the underlying value is needed, but this just shows a real gap in the language for enums that will hopefully be addressed some day.