### PR TITLE
Fix potential regression introduced by #332

### DIFF
--- a/Examples/CaseStudiesTests/PresentationTests.swift
+++ b/Examples/CaseStudiesTests/PresentationTests.swift
@@ -527,6 +527,46 @@ final class PresentationTests: XCTestCase {
     await assertEventuallyEqual(nav.viewControllers.count, 1)
     await assertEventuallyNil(vc.model.pushedChild)
   }
+
+  @MainActor
+  func testRepresentWhileDismissing_StillCallsOnDismiss() async throws {
+    final class DismissCounter { var count = 0 }
+    let counter = DismissCounter()
+
+    final class VC: ViewController {
+      @UIBinding var presentedChild: Model?
+      let counter: DismissCounter
+      init(counter: DismissCounter) {
+        self.counter = counter
+        super.init(nibName: nil, bundle: nil)
+      }
+      required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+      override func viewDidLoad() {
+        super.viewDidLoad()
+        present(item: $presentedChild) { [counter] in
+          counter.count += 1
+        } content: { _ in
+          ViewController()
+        }
+      }
+    }
+
+    let vc = VC(counter: counter)
+    try await setUp(controller: vc)
+
+    vc.presentedChild = Model()
+    await assertEventuallyNotNil(vc.presentedViewController)
+    try await Task.sleep(for: .seconds(0.5))
+
+    vc.presentedChild = Model()
+    try await Task.sleep(for: .seconds(0.05))
+    vc.presentedChild = Model()
+
+    try await Task.sleep(for: .seconds(1))
+    await assertEventuallyNotNil(vc.presentedViewController)
+
+    XCTAssertEqual(counter.count, 2)
+  }
 }
 
 @Observable

--- a/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/Examples.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2c2f5053b9ce91413b6de5f13828e0b1ccbb7044501a2a5b72fb16e377c35f04",
+  "originHash" : "6b615a21818e0d56c77faf90dda16234025a181aa5b5fba0b4faf3f5663edf5b",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-case-paths",
       "state" : {
-        "revision" : "9810c8d6c2914de251e072312f01d3bf80071852",
-        "version" : "1.7.1"
+        "revision" : "1197e80bc7e4b177051b6869ef93d8ac3ad677da",
+        "version" : "1.8.0"
       }
     },
     {
@@ -92,12 +92,30 @@
       }
     },
     {
+      "identity" : "swift-macro-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-macro-testing",
+      "state" : {
+        "revision" : "2e494c632d510715c96a694ff25e2a8d4ac3f64b",
+        "version" : "0.6.5"
+      }
+    },
+    {
       "identity" : "swift-perception",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/pointfreeco/swift-perception",
       "state" : {
         "revision" : "f4f57cac7d273cddf0161293d47adbb5a6ba3aed",
         "version" : "2.0.0"
+      }
+    },
+    {
+      "identity" : "swift-snapshot-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing",
+      "state" : {
+        "revision" : "2e6a85b73fc14e27d7542165ae73b1a10516ca9a",
+        "version" : "1.17.7"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -168,7 +168,7 @@ let package = Package(
         "UIKitNavigationShim",
         .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
       ],
-      linkerSettings: [.unsafeFlags(["-ObjC"])]
+      linkerSettings: [.unsafeFlags(["-Xlinker", "-ObjC"])]
     ),
     .target(
       name: "UIKitNavigationShim"

--- a/Sources/UIKitNavigation/Navigation/Presentation.swift
+++ b/Sources/UIKitNavigation/Navigation/Presentation.swift
@@ -126,6 +126,7 @@
             let oldViewControllerOnDismiss = presentedViewController._UIKitNavigation_onDismiss
             presentedViewController._UIKitNavigation_onDismiss = {
               oldViewControllerOnDismiss?()
+              onDismiss?()
               self.present(child, animated: !transaction.uiKit.disablesAnimations)
             }
           } else {


### PR DESCRIPTION
The double-dismiss bug fixed by #332 is an improvement but made it so the optional `onDismiss` callback might not get hit during such a dismissal.

Added a regression test and fix.