### PR TITLE
Re-present alerts on identity change

### DIFF
--- a/Sources/SwiftUINavigation/Alert+State.swift
+++ b/Sources/SwiftUINavigation/Alert+State.swift
@@ -2,6 +2,7 @@
   public import SwiftNavigation
   public import SwiftUI
 
+  @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
   extension View {
     /// Presents an alert from a binding to optional alert state.
     ///

--- a/Sources/SwiftUINavigation/Alert+State.swift
+++ b/Sources/SwiftUINavigation/Alert+State.swift
@@ -1,0 +1,171 @@
+#if canImport(SwiftUI)
+  public import SwiftNavigation
+  public import SwiftUI
+
+  extension View {
+    /// Presents an alert from a binding to optional alert state.
+    ///
+    /// See <doc:AlertsDialogs> for more information on how to use this API.
+    ///
+    /// - Parameter state: A binding to optional alert state that determines whether an alert should
+    ///   be presented. When the binding is updated with non-`nil` value, it is unwrapped and used
+    ///   to populate the fields of an alert that the system displays to the user. When the user
+    ///   presses or taps one of the alert's actions, the system sets this value to `nil` and
+    ///   dismisses the alert, and the action is fed to the `action` closure.
+    #if compiler(>=6)
+      @MainActor
+    #endif
+    public func alert(_ state: Binding<AlertState<Never>?>) -> some View {
+      alert(state) { _ in }
+    }
+
+    /// Presents an alert from a binding to optional alert state.
+    ///
+    /// See <doc:AlertsDialogs> for more information on how to use this API.
+    ///
+    /// - Parameters:
+    ///   - state: A binding to optional alert state that determines whether an alert should be
+    ///     presented. When the binding is updated with non-`nil` value, it is unwrapped and used to
+    ///     populate the fields of an alert that the system displays to the user. When the user
+    ///     presses or taps one of the alert's actions, the system sets this value to `nil` and
+    ///     dismisses the alert, and the action is fed to the `action` closure.
+    ///   - handler: A closure that is called with an action from a particular alert button when
+    ///     tapped.
+    #if compiler(>=6)
+      @MainActor
+    #endif
+    public func alert<Value>(
+      _ state: Binding<AlertState<Value>?>,
+      action handler: @escaping (Value?) -> Void
+    ) -> some View {
+      alert(item: state) {
+        Text($0.title)
+      } actions: {
+        ForEach($0.buttons) {
+          Button($0, action: handler)
+        }
+      } message: {
+        $0.message.map(Text.init)
+      }
+    }
+
+    /// Presents an alert from a binding to optional alert state.
+    ///
+    /// See <doc:AlertsDialogs> for more information on how to use this API.
+    ///
+    /// > Warning: Async closures cannot be performed with animation. If the underlying action is
+    /// > animated, a runtime warning will be emitted.
+    ///
+    /// - Parameters:
+    ///   - state: A binding to optional alert state that determines whether an alert should be
+    ///     presented. When the binding is updated with non-`nil` value, it is unwrapped and used to
+    ///     populate the fields of an alert that the system displays to the user. When the user
+    ///     presses or taps one of the alert's actions, the system sets this value to `nil` and
+    ///     dismisses the alert, and the action is fed to the `action` closure.
+    ///   - handler: A closure that is called with an action from a particular alert button when
+    ///     tapped.
+    public func alert<Value: Sendable>(
+      _ state: Binding<AlertState<Value>?>,
+      action handler: @escaping @Sendable (Value?) async -> Void
+    ) -> some View {
+      alert(item: state) {
+        Text($0.title)
+      } actions: {
+        ForEach($0.buttons) {
+          Button($0, action: handler)
+        }
+      } message: {
+        $0.message.map(Text.init)
+      }
+    }
+  }
+
+  @available(
+    iOS,
+    introduced: 13,
+    deprecated: 100000,
+    message: "use 'View.alert(_:action:)' instead."
+  )
+  @available(
+    macOS,
+    introduced: 10.15,
+    deprecated: 100000,
+    message: "use 'View.alert(_:action:)' instead."
+  )
+  @available(
+    tvOS,
+    introduced: 13,
+    deprecated: 100000,
+    message: "use 'View.alert(_:action:)' instead."
+  )
+  @available(
+    watchOS,
+    introduced: 6,
+    deprecated: 100000,
+    message: "use 'View.alert(_:action:)' instead."
+  )
+  extension Alert {
+    /// Creates an alert from alert state.
+    ///
+    /// - Parameters:
+    ///   - state: Alert state used to populate the alert.
+    ///   - action: An action handler, called when a button with an action is tapped, by passing the
+    ///     action to the closure.
+    public init<Action>(_ state: AlertState<Action>, action: @escaping (Action?) -> Void) {
+      if state.buttons.count <= 1 {
+        self.init(
+          title: Text(state.title),
+          message: state.message.map { Text($0) },
+          dismissButton: state.buttons.first.map { .init($0, action: action) }
+        )
+      } else {
+        if state.buttons.count > 2 {
+          reportIssue(
+            """
+            'Alert' handed 'AlertState' with too many buttons. Will only display the first two.
+            """
+          )
+        }
+        self.init(
+          title: Text(state.title),
+          message: state.message.map { Text($0) },
+          primaryButton: .init(state.buttons[0], action: action),
+          secondaryButton: .init(state.buttons[1], action: action)
+        )
+      }
+    }
+
+    /// Creates an alert from alert state.
+    ///
+    /// - Parameters:
+    ///   - state: Alert state used to populate the alert.
+    ///   - action: An action handler, called when a button with an action is tapped, by passing the
+    ///     action to the closure.
+    public init<Action: Sendable>(
+      _ state: AlertState<Action>,
+      action: @escaping @Sendable (Action?) async -> Void
+    ) {
+      if state.buttons.count <= 1 {
+        self.init(
+          title: Text(state.title),
+          message: state.message.map { Text($0) },
+          dismissButton: state.buttons.first.map { .init($0, action: action) }
+        )
+      } else {
+        if state.buttons.count > 2 {
+          reportIssue(
+            """
+            'Alert' handed 'AlertState' with too many buttons. Will only display the first two.
+            """
+          )
+        }
+        self.init(
+          title: Text(state.title),
+          message: state.message.map { Text($0) },
+          primaryButton: .init(state.buttons[0], action: action),
+          secondaryButton: .init(state.buttons[1], action: action)
+        )
+      }
+    }
+  }
+#endif

--- a/Sources/SwiftUINavigation/Alert.swift
+++ b/Sources/SwiftUINavigation/Alert.swift
@@ -237,6 +237,7 @@
     }
   }
 
+  @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
   private struct AlertModifier<Item, Actions: View, Message: View>: ViewModifier {
     @Binding var item: Item?
     var title: Text

--- a/Sources/SwiftUINavigation/Alert.swift
+++ b/Sources/SwiftUINavigation/Alert.swift
@@ -1,5 +1,4 @@
 #if canImport(SwiftUI)
-  public import SwiftNavigation
   public import SwiftUI
 
   @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
@@ -65,12 +64,13 @@
       @ViewBuilder actions: (Item) -> A,
       @ViewBuilder message: (Item) -> M
     ) -> some View {
-      alert(
-        item.wrappedValue.map(title) ?? Text(verbatim: ""),
-        isPresented: Binding(item),
-        presenting: item.wrappedValue,
-        actions: actions,
-        message: message
+      modifier(
+        AlertModifier(
+          item: item,
+          title: title,
+          actions: { actions($0.wrappedValue) },
+          message: message
+        )
       )
     }
 
@@ -94,12 +94,13 @@
       @ViewBuilder actions: (Binding<Item>) -> A,
       @ViewBuilder message: (Item) -> M
     ) -> some View {
-      alert(
-        item.wrappedValue.map(title) ?? Text(verbatim: ""),
-        isPresented: Binding(item),
-        presenting: item.wrappedValue,
-        actions: { actions(Binding(unwrapping: item, default: $0)) },
-        message: message
+      modifier(
+        AlertModifier(
+          item: item,
+          title: title,
+          actions: actions,
+          message: message
+        )
       )
     }
 
@@ -158,11 +159,13 @@
       title: (Item) -> Text,
       @ViewBuilder actions: (Item) -> A
     ) -> some View {
-      alert(
-        item.wrappedValue.map(title) ?? Text(verbatim: ""),
-        isPresented: Binding(item),
-        presenting: item.wrappedValue,
-        actions: actions
+      modifier(
+        AlertModifier(
+          item: item,
+          title: title,
+          actions: { actions($0.wrappedValue) },
+          message: { _ in }
+        )
       )
     }
 
@@ -223,177 +226,56 @@
       title: (Item) -> Text,
       @ViewBuilder actions: (Binding<Item>) -> A
     ) -> some View {
-      alert(
-        item.wrappedValue.map(title) ?? Text(verbatim: ""),
-        isPresented: Binding(item),
-        presenting: item.wrappedValue,
-        actions: { actions(Binding(unwrapping: item, default: $0)) }
+      modifier(
+        AlertModifier(
+          item: item,
+          title: title,
+          actions: actions,
+          message: { _ in }
+        )
       )
-    }
-
-    /// Presents an alert from a binding to optional alert state.
-    ///
-    /// See <doc:AlertsDialogs> for more information on how to use this API.
-    ///
-    /// - Parameter state: A binding to optional alert state that determines whether an alert should
-    ///   be presented. When the binding is updated with non-`nil` value, it is unwrapped and used
-    ///   to populate the fields of an alert that the system displays to the user. When the user
-    ///   presses or taps one of the alert's actions, the system sets this value to `nil` and
-    ///   dismisses the alert, and the action is fed to the `action` closure.
-    #if compiler(>=6)
-      @MainActor
-    #endif
-    public func alert(_ state: Binding<AlertState<Never>?>) -> some View {
-      alert(state) { _ in }
-    }
-
-    /// Presents an alert from a binding to optional alert state.
-    ///
-    /// See <doc:AlertsDialogs> for more information on how to use this API.
-    ///
-    /// - Parameters:
-    ///   - state: A binding to optional alert state that determines whether an alert should be
-    ///     presented. When the binding is updated with non-`nil` value, it is unwrapped and used to
-    ///     populate the fields of an alert that the system displays to the user. When the user
-    ///     presses or taps one of the alert's actions, the system sets this value to `nil` and
-    ///     dismisses the alert, and the action is fed to the `action` closure.
-    ///   - handler: A closure that is called with an action from a particular alert button when
-    ///     tapped.
-    #if compiler(>=6)
-      @MainActor
-    #endif
-    public func alert<Value>(
-      _ state: Binding<AlertState<Value>?>,
-      action handler: @escaping (Value?) -> Void
-    ) -> some View {
-      alert(item: state) {
-        Text($0.title)
-      } actions: {
-        ForEach($0.buttons) {
-          Button($0, action: handler)
-        }
-      } message: {
-        $0.message.map(Text.init)
-      }
-    }
-
-    /// Presents an alert from a binding to optional alert state.
-    ///
-    /// See <doc:AlertsDialogs> for more information on how to use this API.
-    ///
-    /// > Warning: Async closures cannot be performed with animation. If the underlying action is
-    /// > animated, a runtime warning will be emitted.
-    ///
-    /// - Parameters:
-    ///   - state: A binding to optional alert state that determines whether an alert should be
-    ///     presented. When the binding is updated with non-`nil` value, it is unwrapped and used to
-    ///     populate the fields of an alert that the system displays to the user. When the user
-    ///     presses or taps one of the alert's actions, the system sets this value to `nil` and
-    ///     dismisses the alert, and the action is fed to the `action` closure.
-    ///   - handler: A closure that is called with an action from a particular alert button when
-    ///     tapped.
-    public func alert<Value: Sendable>(
-      _ state: Binding<AlertState<Value>?>,
-      action handler: @escaping @Sendable (Value?) async -> Void
-    ) -> some View {
-      alert(item: state) {
-        Text($0.title)
-      } actions: {
-        ForEach($0.buttons) {
-          Button($0, action: handler)
-        }
-      } message: {
-        $0.message.map(Text.init)
-      }
     }
   }
 
-  @available(
-    iOS,
-    introduced: 13,
-    deprecated: 100000,
-    message: "use 'View.alert(_:action:)' instead."
-  )
-  @available(
-    macOS,
-    introduced: 10.15,
-    deprecated: 100000,
-    message: "use 'View.alert(_:action:)' instead."
-  )
-  @available(
-    tvOS,
-    introduced: 13,
-    deprecated: 100000,
-    message: "use 'View.alert(_:action:)' instead."
-  )
-  @available(
-    watchOS,
-    introduced: 6,
-    deprecated: 100000,
-    message: "use 'View.alert(_:action:)' instead."
-  )
-  extension Alert {
-    /// Creates an alert from alert state.
-    ///
-    /// - Parameters:
-    ///   - state: Alert state used to populate the alert.
-    ///   - action: An action handler, called when a button with an action is tapped, by passing the
-    ///     action to the closure.
-    public init<Action>(_ state: AlertState<Action>, action: @escaping (Action?) -> Void) {
-      if state.buttons.count <= 1 {
-        self.init(
-          title: Text(state.title),
-          message: state.message.map { Text($0) },
-          dismissButton: state.buttons.first.map { .init($0, action: action) }
-        )
-      } else {
-        if state.buttons.count > 2 {
-          reportIssue(
-            """
-            'Alert' handed 'AlertState' with too many buttons. Will only display the first two.
-            """
-          )
-        }
-        self.init(
-          title: Text(state.title),
-          message: state.message.map { Text($0) },
-          primaryButton: .init(state.buttons[0], action: action),
-          secondaryButton: .init(state.buttons[1], action: action)
-        )
-      }
+  private struct AlertModifier<Item, Actions: View, Message: View>: ViewModifier {
+    @Binding var item: Item?
+    var title: Text
+    var actions: Actions?
+    var message: Message?
+    @State private var isPresented = false
+
+    init(
+      item: Binding<Item?>,
+      title: (Item) -> Text,
+      @ViewBuilder actions: (Binding<Item>) -> Actions,
+      @ViewBuilder message: (Item) -> Message
+    ) {
+      self._item = item
+      self.title = item.wrappedValue.map(title) ?? Text(verbatim: "")
+      self.actions = Binding(unwrapping: item).map(actions)
+      self.message = item.wrappedValue.map(message)
+      self.isPresented = _item.wrappedValue != nil
     }
 
-    /// Creates an alert from alert state.
-    ///
-    /// - Parameters:
-    ///   - state: Alert state used to populate the alert.
-    ///   - action: An action handler, called when a button with an action is tapped, by passing the
-    ///     action to the closure.
-    public init<Action: Sendable>(
-      _ state: AlertState<Action>,
-      action: @escaping @Sendable (Action?) async -> Void
-    ) {
-      if state.buttons.count <= 1 {
-        self.init(
-          title: Text(state.title),
-          message: state.message.map { Text($0) },
-          dismissButton: state.buttons.first.map { .init($0, action: action) }
+    func body(content: Content) -> some View {
+      let id = (item as? any Identifiable)?.id as? AnyHashable
+      content
+        .alert(
+          title,
+          isPresented: $isPresented,
+          presenting: item,
+          actions: { _ in actions },
+          message: { _ in message }
         )
-      } else {
-        if state.buttons.count > 2 {
-          reportIssue(
-            """
-            'Alert' handed 'AlertState' with too many buttons. Will only display the first two.
-            """
-          )
+        .onChange(of: id) { [oldValue = id] newValue in
+          switch (oldValue, newValue) {
+          case (_?, _?):
+            isPresented = false
+            Task { isPresented = item != nil }
+          case (_?, nil), (nil, _?), (nil, nil):
+            isPresented = item != nil
+          }
         }
-        self.init(
-          title: Text(state.title),
-          message: state.message.map { Text($0) },
-          primaryButton: .init(state.buttons[0], action: action),
-          secondaryButton: .init(state.buttons[1], action: action)
-        )
-      }
     }
   }
 #endif

--- a/Sources/SwiftUINavigation/ConfirmationDialog+State.swift
+++ b/Sources/SwiftUINavigation/ConfirmationDialog+State.swift
@@ -1,0 +1,140 @@
+#if canImport(SwiftUI)
+  public import SwiftNavigation
+  public import SwiftUI
+
+  @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
+  extension Visibility {
+    public init(_ visibility: ConfirmationDialogStateTitleVisibility) {
+      switch visibility {
+      case .automatic:
+        self = .automatic
+      case .hidden:
+        self = .hidden
+      case .visible:
+        self = .visible
+      @unknown default:
+        self = .automatic
+      }
+    }
+  }
+
+  @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
+  extension View {
+    /// Presents a confirmation dialog from a binding to optional confirmation dialog state.
+    ///
+    /// See <doc:AlertsDialogs> for more information on how to use this API.
+    ///
+    /// - Parameter state: A binding to optional state that determines whether a confirmation dialog
+    ///   should be presented. When the binding is updated with non-`nil` value, it is unwrapped and
+    ///   used to populate the fields of a dialog that the system displays to the user. When the
+    ///   user presses or taps one of the dialog's actions, the system sets this value to `nil` and
+    ///   dismisses the dialog, and the action is fed to the `action` closure.
+    public func confirmationDialog(
+      _ state: Binding<ConfirmationDialogState<Never>?>,
+    ) -> some View {
+      confirmationDialog(state) { _ in }
+    }
+
+    /// Presents a confirmation dialog from a binding to optional confirmation dialog state.
+    ///
+    /// See <doc:AlertsDialogs> for more information on how to use this API.
+    ///
+    /// - Parameters:
+    ///   - state: A binding to optional state that determines whether a confirmation dialog should
+    ///     be presented. When the binding is updated with non-`nil` value, it is unwrapped and used
+    ///     to populate the fields of a dialog that the system displays to the user. When the user
+    ///     presses or taps one of the dialog's actions, the system sets this value to `nil` and
+    ///     dismisses the dialog, and the action is fed to the `action` closure.
+    ///   - handler: A closure that is called with an action from a particular dialog button when
+    ///     tapped.
+    public func confirmationDialog<Value>(
+      _ state: Binding<ConfirmationDialogState<Value>?>,
+      action handler: @escaping (Value?) -> Void
+    ) -> some View {
+      confirmationDialog(
+        item: state,
+        titleVisibility: state.wrappedValue.map { .init($0.titleVisibility) } ?? .automatic
+      ) {
+        Text($0.title)
+      } actions: {
+        ForEach($0.buttons) {
+          Button($0, action: handler)
+        }
+      } message: {
+        $0.message.map(Text.init)
+      }
+    }
+
+    /// Presents a confirmation dialog from a binding to optional confirmation dialog state.
+    ///
+    /// See <doc:AlertsDialogs> for more information on how to use this API.
+    ///
+    /// > Warning: Async closures cannot be performed with animation. If the underlying action is
+    /// > animated, a runtime warning will be emitted.
+    ///
+    /// - Parameters:
+    ///   - state: A binding to optional state that determines whether a confirmation dialog should
+    ///     be presented. When the binding is updated with non-`nil` value, it is unwrapped and used
+    ///     to populate the fields of a dialog that the system displays to the user. When the user
+    ///     presses or taps one of the dialog's actions, the system sets this value to `nil` and
+    ///     dismisses the dialog, and the action is fed to the `action` closure.
+    ///   - handler: A closure that is called with an action from a particular dialog button when
+    ///     tapped.
+    public func confirmationDialog<Value: Sendable>(
+      _ state: Binding<ConfirmationDialogState<Value>?>,
+      action handler: @escaping @Sendable (Value?) async -> Void
+    ) -> some View {
+      confirmationDialog(
+        item: state,
+        titleVisibility: state.wrappedValue.map { .init($0.titleVisibility) } ?? .automatic
+      ) {
+        Text($0.title)
+      } actions: {
+        ForEach($0.buttons) {
+          Button($0, action: handler)
+        }
+      } message: {
+        $0.message.map(Text.init)
+      }
+    }
+  }
+
+  @available(
+    iOS,
+    introduced: 13,
+    deprecated: 100000,
+    message:
+      "use 'View.confirmationDialog(title:isPresented:titleVisibility:presenting::actions:)' instead."
+  )
+  @available(
+    macOS,
+    introduced: 12,
+    unavailable
+  )
+  @available(
+    tvOS,
+    introduced: 13,
+    deprecated: 100000,
+    message:
+      "use 'View.confirmationDialog(title:isPresented:titleVisibility:presenting::actions:)' instead."
+  )
+  @available(
+    watchOS,
+    introduced: 6,
+    deprecated: 100000,
+    message:
+      "use 'View.confirmationDialog(title:isPresented:titleVisibility:presenting::actions:)' instead."
+  )
+  extension ActionSheet {
+    public init<Action>(
+      _ state: ConfirmationDialogState<Action>,
+      action: @escaping (Action?) -> Void
+    ) {
+      self.init(
+        title: Text(state.title),
+        message: state.message.map { Text($0) },
+        buttons: state.buttons.map { .init($0, action: action) }
+      )
+    }
+  }
+#endif

--- a/Sources/SwiftUINavigation/ConfirmationDialog.swift
+++ b/Sources/SwiftUINavigation/ConfirmationDialog.swift
@@ -1,22 +1,5 @@
 #if canImport(SwiftUI)
-  public import SwiftNavigation
   public import SwiftUI
-
-  @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
-  extension Visibility {
-    public init(_ visibility: ConfirmationDialogStateTitleVisibility) {
-      switch visibility {
-      case .automatic:
-        self = .automatic
-      case .hidden:
-        self = .hidden
-      case .visible:
-        self = .visible
-      @unknown default:
-        self = .automatic
-      }
-    }
-  }
 
   @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
   extension View {
@@ -83,13 +66,14 @@
       @ViewBuilder actions: (Item) -> A,
       @ViewBuilder message: (Item) -> M
     ) -> some View {
-      confirmationDialog(
-        item.wrappedValue.map(title) ?? Text(verbatim: ""),
-        isPresented: Binding(item),
-        titleVisibility: titleVisibility,
-        presenting: item.wrappedValue,
-        actions: actions,
-        message: message
+      modifier(
+        ConfirmationDialogModifier(
+          item: item,
+          titleVisibility: titleVisibility,
+          title: title,
+          actions: actions,
+          message: message
+        )
       )
     }
 
@@ -152,130 +136,61 @@
       title: (Item) -> Text,
       @ViewBuilder actions: (Item) -> A
     ) -> some View {
-      confirmationDialog(
-        item.wrappedValue.map(title) ?? Text(verbatim: ""),
-        isPresented: Binding(item),
-        titleVisibility: titleVisibility,
-        presenting: item.wrappedValue,
-        actions: actions
+      modifier(
+        ConfirmationDialogModifier(
+          item: item,
+          titleVisibility: titleVisibility,
+          title: title,
+          actions: actions,
+          message: { _ in }
+        )
       )
-    }
-
-    /// Presents a confirmation dialog from a binding to optional confirmation dialog state.
-    ///
-    /// See <doc:AlertsDialogs> for more information on how to use this API.
-    ///
-    /// - Parameter state: A binding to optional state that determines whether a confirmation dialog
-    ///   should be presented. When the binding is updated with non-`nil` value, it is unwrapped and
-    ///   used to populate the fields of a dialog that the system displays to the user. When the
-    ///   user presses or taps one of the dialog's actions, the system sets this value to `nil` and
-    ///   dismisses the dialog, and the action is fed to the `action` closure.
-    public func confirmationDialog(
-      _ state: Binding<ConfirmationDialogState<Never>?>,
-    ) -> some View {
-      confirmationDialog(state) { _ in }
-    }
-
-    /// Presents a confirmation dialog from a binding to optional confirmation dialog state.
-    ///
-    /// See <doc:AlertsDialogs> for more information on how to use this API.
-    ///
-    /// - Parameters:
-    ///   - state: A binding to optional state that determines whether a confirmation dialog should
-    ///     be presented. When the binding is updated with non-`nil` value, it is unwrapped and used
-    ///     to populate the fields of a dialog that the system displays to the user. When the user
-    ///     presses or taps one of the dialog's actions, the system sets this value to `nil` and
-    ///     dismisses the dialog, and the action is fed to the `action` closure.
-    ///   - handler: A closure that is called with an action from a particular dialog button when
-    ///     tapped.
-    public func confirmationDialog<Value>(
-      _ state: Binding<ConfirmationDialogState<Value>?>,
-      action handler: @escaping (Value?) -> Void
-    ) -> some View {
-      confirmationDialog(
-        item: state,
-        titleVisibility: state.wrappedValue.map { .init($0.titleVisibility) } ?? .automatic
-      ) {
-        Text($0.title)
-      } actions: {
-        ForEach($0.buttons) {
-          Button($0, action: handler)
-        }
-      } message: {
-        $0.message.map(Text.init)
-      }
-    }
-
-    /// Presents a confirmation dialog from a binding to optional confirmation dialog state.
-    ///
-    /// See <doc:AlertsDialogs> for more information on how to use this API.
-    ///
-    /// > Warning: Async closures cannot be performed with animation. If the underlying action is
-    /// > animated, a runtime warning will be emitted.
-    ///
-    /// - Parameters:
-    ///   - state: A binding to optional state that determines whether a confirmation dialog should
-    ///     be presented. When the binding is updated with non-`nil` value, it is unwrapped and used
-    ///     to populate the fields of a dialog that the system displays to the user. When the user
-    ///     presses or taps one of the dialog's actions, the system sets this value to `nil` and
-    ///     dismisses the dialog, and the action is fed to the `action` closure.
-    ///   - handler: A closure that is called with an action from a particular dialog button when
-    ///     tapped.
-    public func confirmationDialog<Value: Sendable>(
-      _ state: Binding<ConfirmationDialogState<Value>?>,
-      action handler: @escaping @Sendable (Value?) async -> Void
-    ) -> some View {
-      confirmationDialog(
-        item: state,
-        titleVisibility: state.wrappedValue.map { .init($0.titleVisibility) } ?? .automatic
-      ) {
-        Text($0.title)
-      } actions: {
-        ForEach($0.buttons) {
-          Button($0, action: handler)
-        }
-      } message: {
-        $0.message.map(Text.init)
-      }
     }
   }
 
-  @available(
-    iOS,
-    introduced: 13,
-    deprecated: 100000,
-    message:
-      "use 'View.confirmationDialog(title:isPresented:titleVisibility:presenting::actions:)' instead."
-  )
-  @available(
-    macOS,
-    introduced: 12,
-    unavailable
-  )
-  @available(
-    tvOS,
-    introduced: 13,
-    deprecated: 100000,
-    message:
-      "use 'View.confirmationDialog(title:isPresented:titleVisibility:presenting::actions:)' instead."
-  )
-  @available(
-    watchOS,
-    introduced: 6,
-    deprecated: 100000,
-    message:
-      "use 'View.confirmationDialog(title:isPresented:titleVisibility:presenting::actions:)' instead."
-  )
-  extension ActionSheet {
-    public init<Action>(
-      _ state: ConfirmationDialogState<Action>,
-      action: @escaping (Action?) -> Void
+  private struct ConfirmationDialogModifier<Item, Actions: View, Message: View>: ViewModifier {
+    @Binding var item: Item?
+    var titleVisibility: Visibility
+    var title: Text
+    var actions: Actions?
+    var message: Message?
+    @State private var isPresented = false
+
+    init(
+      item: Binding<Item?>,
+      titleVisibility: Visibility,
+      title: (Item) -> Text,
+      @ViewBuilder actions: (Item) -> Actions,
+      @ViewBuilder message: (Item) -> Message
     ) {
-      self.init(
-        title: Text(state.title),
-        message: state.message.map { Text($0) },
-        buttons: state.buttons.map { .init($0, action: action) }
-      )
+      self._item = item
+      self.titleVisibility = titleVisibility
+      self.title = item.wrappedValue.map(title) ?? Text(verbatim: "")
+      self.actions = item.wrappedValue.map(actions)
+      self.message = item.wrappedValue.map(message)
+      self.isPresented = _item.wrappedValue != nil
+    }
+
+    func body(content: Content) -> some View {
+      let id = (item as? any Identifiable)?.id as? AnyHashable
+      content
+        .confirmationDialog(
+          title,
+          isPresented: $isPresented,
+          titleVisibility: titleVisibility,
+          presenting: item,
+          actions: { _ in actions },
+          message: { _ in message }
+        )
+        .onChange(of: id) { [oldValue = id] newValue in
+          switch (oldValue, newValue) {
+          case (_?, _?):
+            isPresented = false
+            Task { isPresented = item != nil }
+          case (_?, nil), (nil, _?), (nil, nil):
+            isPresented = item != nil
+          }
+        }
     }
   }
 #endif

--- a/Sources/SwiftUINavigation/ConfirmationDialog.swift
+++ b/Sources/SwiftUINavigation/ConfirmationDialog.swift
@@ -148,6 +148,7 @@
     }
   }
 
+  @available(iOS 15, macOS 12, tvOS 15, watchOS 8, *)
   private struct ConfirmationDialogModifier<Item, Actions: View, Message: View>: ViewModifier {
     @Binding var item: Item?
     var titleVisibility: Visibility


### PR DESCRIPTION
This was a feature of iOS 13 alerts that was no longer supported in iOS 15 and still not supported in iOS 27. Let's recover it in our APIs.

It's a runtime concern for now, but we could consider deprecating the existing, non-`Identifiable` APIs in the future, and provide an `id:` parameter for deriving one live.