### PR TITLE
Remove swift-collections dependency

### DIFF
--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -51,7 +51,6 @@ let package = Package(
         .product(name: "CustomDump", package: "swift-custom-dump"),
         .product(name: "ConcurrencyExtras", package: "swift-concurrency-extras"),
         .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
-        .product(name: "OrderedCollections", package: "swift-collections"),
         .product(name: "Perception", package: "swift-perception"),
         .product(name: "PerceptionCore", package: "swift-perception"),
       ]

--- a/Package@swift-6.1.swift
+++ b/Package@swift-6.1.swift
@@ -97,7 +97,6 @@ let package = Package(
             "IssueReporting"
           ])
         ),
-        .product(name: "OrderedCollections", package: "swift-collections"),
         .product(name: "Perception", package: "swift-perception"),
         .product(name: "PerceptionCore", package: "swift-perception"),
         .product(

--- a/Sources/SwiftNavigation/Observe.swift
+++ b/Sources/SwiftNavigation/Observe.swift
@@ -1,5 +1,4 @@
 import ConcurrencyExtras
-import OrderedCollections
 import PerceptionCore
 
 #if swift(>=6)

--- a/Sources/SwiftNavigation/UITransaction.swift
+++ b/Sources/SwiftNavigation/UITransaction.swift
@@ -1,5 +1,3 @@
-import OrderedCollections
-
 /// Executes a closure with the specified transaction and returns the result.
 ///
 /// - Parameters:
@@ -41,7 +39,7 @@ public func withUITransaction<R, V>(
 public struct UITransaction: Sendable {
   @TaskLocal package static var current = Self()
 
-  var storage: OrderedDictionary<Key, any Sendable> = [:]
+  var storage: [Key: any Sendable] = [:]
 
   /// Creates a transaction.
   public init() {}
@@ -77,7 +75,7 @@ public struct UITransaction: Sendable {
     Self(storage: storage.merging(other.storage, uniquingKeysWith: { $1 }))
   }
 
-  private init(storage: OrderedDictionary<Key, any Sendable>) {
+  private init(storage: [Key: any Sendable]) {
     self.storage = storage
   }
 

--- a/SwiftNavigation.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SwiftNavigation.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "6b615a21818e0d56c77faf90dda16234025a181aa5b5fba0b4faf3f5663edf5b",
+  "originHash" : "2345d29010f6381f0f5678cbef1747018a89f8f0c0ebea4b0e5e10d4a8d539d1",
   "pins" : [
     {
       "identity" : "combine-schedulers",


### PR DESCRIPTION
The ordered dictionary dependency is actually not needed, so let's drop it.