### PR TITLE
Fix re-presenting of alerts/dialogs

### DIFF
--- a/Sources/SwiftUINavigation/Alert.swift
+++ b/Sources/SwiftUINavigation/Alert.swift
@@ -243,7 +243,6 @@
     var title: Text
     var actions: Actions?
     var message: Message?
-    @Binding private var isPresented: Bool
 
     init(
       item: Binding<Item?>,
@@ -255,7 +254,6 @@
       self.title = item.wrappedValue.map(title) ?? Text(verbatim: "")
       self.actions = Binding(unwrapping: item).map(actions)
       self.message = item.wrappedValue.map(message)
-      self._isPresented = Binding(item)
     }
 
     func body(content: Content) -> some View {
@@ -263,7 +261,7 @@
       content
         .alert(
           title,
-          isPresented: $isPresented,
+          isPresented: Binding($item),
           presenting: item,
           actions: { _ in actions },
           message: { _ in message }
@@ -271,10 +269,11 @@
         .onChange(of: id) { [oldValue = id] newValue in
           switch (oldValue, newValue) {
           case (_?, _?):
-            isPresented = false
-            Task { isPresented = item != nil }
+            let newItem = item
+            item = nil
+            Task { item = newItem }
           case (_?, nil), (nil, _?), (nil, nil):
-            isPresented = item != nil
+            break
           }
         }
     }

--- a/Sources/SwiftUINavigation/ConfirmationDialog.swift
+++ b/Sources/SwiftUINavigation/ConfirmationDialog.swift
@@ -155,7 +155,6 @@
     var title: Text
     var actions: Actions?
     var message: Message?
-    @Binding private var isPresented: Bool
 
     init(
       item: Binding<Item?>,
@@ -169,7 +168,6 @@
       self.title = item.wrappedValue.map(title) ?? Text(verbatim: "")
       self.actions = item.wrappedValue.map(actions)
       self.message = item.wrappedValue.map(message)
-      self._isPresented = Binding(item)
     }
 
     func body(content: Content) -> some View {
@@ -177,7 +175,7 @@
       content
         .confirmationDialog(
           title,
-          isPresented: $isPresented,
+          isPresented: Binding($item),
           titleVisibility: titleVisibility,
           presenting: item,
           actions: { _ in actions },
@@ -186,10 +184,11 @@
         .onChange(of: id) { [oldValue = id] newValue in
           switch (oldValue, newValue) {
           case (_?, _?):
-            isPresented = false
-            Task { isPresented = item != nil }
+            let newItem = item
+            item = nil
+            Task { item = newItem }
           case (_?, nil), (nil, _?), (nil, nil):
-            isPresented = item != nil
+            break
           }
         }
     }


### PR DESCRIPTION
By combining state in #355 we lost the replacement alert/dialog. Let's get a temporary reference to the new item so it can be re-presented after a tick.