### PR TITLE
Fix Xcode <27 logger availability when `IssueReporting` is disabled

### DIFF
--- a/Sources/SwiftNavigation/ButtonState.swift
+++ b/Sources/SwiftNavigation/ButtonState.swift
@@ -86,23 +86,25 @@ public struct ButtonState<Action>: Identifiable {
       await perform(action)
     #if canImport(SwiftUI)
       case .animatedSend(let action, _):
-        var output = ""
-        #if CustomDump
-          customDump(action, to: &output, indent: 4)
-        #else
-          output.append("    \(action)")
-        #endif
-        reportIssue(
-          """
-          An animated action was performed asynchronously: …
+        if let action {
+          var output = ""
+          #if CustomDump
+            customDump(action, to: &output, indent: 4)
+          #else
+            output.append("    \(String(describing: action))")
+          #endif
+          reportIssue(
+            """
+            An animated action was performed asynchronously: …
 
-            Action:
-          \((output))
+              Action:
+            \((output))
 
-          Asynchronous actions cannot be animated. Evaluate this action in a synchronous closure, \
-          or use 'SwiftUI.withAnimation' explicitly.
-          """
-        )
+            Asynchronous actions cannot be animated. Evaluate this action in a synchronous \
+            closure, or use 'SwiftUI.withAnimation' explicitly.
+            """
+          )
+        }
         await perform(action)
     #endif
     }

--- a/Sources/SwiftNavigation/Traits/IssueReporting.swift
+++ b/Sources/SwiftNavigation/Traits/IssueReporting.swift
@@ -3,6 +3,7 @@
 #elseif canImport(os)
   import os
 
+  @available(iOS 14, macOS 11, tvOS 14, watchOS 7, *)
   private let logger = Logger(subsystem: "SwiftNavigation", category: "Runtime Issues")
 #endif
 
@@ -24,7 +25,11 @@ package func reportIssue(
       column: column
     )
   #elseif canImport(os)
-    logger.warning("\(message)")
+    if #available(iOS 14, macOS 11, tvOS 14, watchOS 7, *) {
+      logger.warning("\(message)")
+    } else {
+      print(message)
+    }
   #else
     print(message)
   #endif


### PR DESCRIPTION
Fixes #357.