### PR TITLE
Enable `CheckImplementationOnly` experimental feature

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -223,6 +223,7 @@ package.traits.insert(
 for target in package.targets {
   target.swiftSettings = target.swiftSettings ?? []
   target.swiftSettings?.append(contentsOf: [
+    .enableExperimentalFeature("CheckImplementationOnly"),
     .enableUpcomingFeature("ExistentialAny"),
     .enableUpcomingFeature("ImmutableWeakCaptures"),
     .enableUpcomingFeature("InferIsolatedConformances"),


### PR DESCRIPTION
New to 6.3, it helps suppress an internal warning we previously couldn't avoid.