### PR TITLE
Remove `SwiftUINavigation` dependency on `UIKitNavigation`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -148,7 +148,6 @@ let package = Package(
     .target(
       name: "SwiftUINavigation",
       dependencies: [
-        "UIKitNavigation",
         .product(
           name: "CasePaths",
           package: "swift-case-paths",

--- a/Package.swift
+++ b/Package.swift
@@ -148,6 +148,7 @@ let package = Package(
     .target(
       name: "SwiftUINavigation",
       dependencies: [
+        "SwiftNavigation",
         .product(
           name: "CasePaths",
           package: "swift-case-paths",

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -81,7 +81,6 @@ let package = Package(
     .target(
       name: "SwiftUINavigation",
       dependencies: [
-        "UIKitNavigation",
         .product(name: "CasePaths", package: "swift-case-paths"),
         .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
       ]

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -81,6 +81,7 @@ let package = Package(
     .target(
       name: "SwiftUINavigation",
       dependencies: [
+        "SwiftNavigation",
         .product(name: "CasePaths", package: "swift-case-paths"),
         .product(name: "IssueReporting", package: "xctest-dynamic-overlay"),
       ]

--- a/Package@swift-6.1.swift
+++ b/Package@swift-6.1.swift
@@ -148,7 +148,6 @@ let package = Package(
     .target(
       name: "SwiftUINavigation",
       dependencies: [
-        "UIKitNavigation",
         .product(
           name: "CasePaths",
           package: "swift-case-paths",

--- a/Package@swift-6.1.swift
+++ b/Package@swift-6.1.swift
@@ -148,6 +148,7 @@ let package = Package(
     .target(
       name: "SwiftUINavigation",
       dependencies: [
+        "SwiftNavigation",
         .product(
           name: "CasePaths",
           package: "swift-case-paths",


### PR DESCRIPTION
This dependency is not necessary, and may be a relic from an earlier version of SwiftNavigation.