### PR TITLE
Fix duplicated words in documentation

### DIFF
--- a/Sources/SwiftNavigation/UIBindable.swift
+++ b/Sources/SwiftNavigation/UIBindable.swift
@@ -66,7 +66,7 @@ public struct UIBindable<Value> {
 
   /// Creates a bindable object from a perceptible object.
   ///
-  /// This initializer is equivalent to `init(wrappedValue:)`, but is more succinct when when
+  /// This initializer is equivalent to `init(wrappedValue:)`, but is more succinct when
   /// creating bindable objects nested within other expressions.
   @_disfavoredOverload
   #if !Perception
@@ -146,7 +146,7 @@ public struct UIBindable<Value> {
   extension UIBindable where Value: AnyObject & Observable {
     /// Creates a bindable object from an observable object.
     ///
-    /// This initializer is equivalent to `init(wrappedValue:)`, but is more succinct when when
+    /// This initializer is equivalent to `init(wrappedValue:)`, but is more succinct when
     /// creating bindable objects nested within other expressions.
     public init(
       _ wrappedValue: Value,

--- a/Sources/UIKitNavigation/Bindings/UITextField.swift
+++ b/Sources/UIKitNavigation/Bindings/UITextField.swift
@@ -148,7 +148,7 @@
 
     /// Modifies this text field by binding its focus state to the given state value.
     ///
-    /// Use this modifier to cause the text field to receive focus whenever the the `binding` equals
+    /// Use this modifier to cause the text field to receive focus whenever the `binding` equals
     /// the `value`. Typically, you create an enumeration of fields that may receive focus, bind an
     /// instance of this enumeration, and assign its cases to focusable text fields.
     ///
@@ -249,7 +249,7 @@
 
     /// Binds this text field's focus state to the given Boolean state value.
     ///
-    /// Use this method to cause the text field to receive focus whenever the the `condition` value
+    /// Use this method to cause the text field to receive focus whenever the `condition` value
     /// is `true`. You can use this method to observe the focus state of a text field, or
     /// programmatically set and remove focus from the text field.
     ///

--- a/Sources/UIKitNavigation/Documentation.docc/UIKitNavigation.md
+++ b/Sources/UIKitNavigation/Documentation.docc/UIKitNavigation.md
@@ -104,7 +104,7 @@ with the view. When the state becomes non-`nil` the corresponding form of naviga
 triggered, and when the presented view is dismissed, the state will be `nil`'d out.
 
 Another powerful aspect of SwiftUI is its ability to update its UI whenever state in an observable
-model changes. And thanks to Swift's observation tools this can be done done implicitly and 
+model changes. And thanks to Swift's observation tools this can be done implicitly and 
 minimally: whichever fields are accessed in the `body` of the view are automatically tracked 
 so that when they change the view updates.
 


### PR DESCRIPTION
A few duplicated words in doc comments:

- `Sources/UIKitNavigation/Bindings/UITextField.swift`: "receive focus whenever the the `binding`/`condition`" -> "whenever the ...".
- `Sources/SwiftNavigation/UIBindable.swift`: "more succinct when when" -> "more succinct when" (2 initializers).
- `Sources/UIKitNavigation/Documentation.docc/UIKitNavigation.md`: "this can be done done implicitly" -> "be done implicitly".

Documentation only.
